### PR TITLE
Check for null

### DIFF
--- a/Graphics/GraphicsEngineVulkan/src/VulkanUtilities/VulkanInstance.cpp
+++ b/Graphics/GraphicsEngineVulkan/src/VulkanUtilities/VulkanInstance.cpp
@@ -110,8 +110,11 @@ namespace VulkanUtilities
 #endif
         };
 
-        for (uint32_t ext = 0; ext < GlobalExtensionCount; ++ext)
-            GlobalExtensions.push_back(ppGlobalExtensionNames[ext]);
+        if (ppGlobalExtensionNames != nullptr)
+        {
+            for (uint32_t ext = 0; ext < GlobalExtensionCount; ++ext)
+                GlobalExtensions.push_back(ppGlobalExtensionNames[ext]);
+        }
 
         for(const auto* ExtName : GlobalExtensions)
         {


### PR DESCRIPTION
When trying to create a hello world triangle I ran into a crash with ppGlobalExtensionNames being null. Maybe I set things up wrong? If not, this code fixed it.