### PR TITLE
Added native window handle wrapper for supported platforms

### DIFF
--- a/Graphics/GraphicsEngine/interface/GraphicsTypes.h
+++ b/Graphics/GraphicsEngine/interface/GraphicsTypes.h
@@ -35,6 +35,7 @@
 #include "../../../Primitives/interface/BasicTypes.h"
 #include "../../../Primitives/interface/DebugOutput.h"
 #include "../../../Primitives/interface/FlagEnum.h"
+#include "../../../Platforms/interface/NativeWindow.h"
 #include "APIInfo.h"
 
 /// Graphics engine namespace
@@ -1318,21 +1319,11 @@ struct EngineCreateInfo
 };
 typedef struct EngineCreateInfo EngineCreateInfo;
 
-
 /// Attributes of the OpenGL-based engine implementation
 struct EngineGLCreateInfo DILIGENT_DERIVE(EngineCreateInfo)
 
-    /// Native window handle
-
-    /// * On Win32 platform, this is a window handle (HWND)
-    /// * On Android platform, this is a pointer to the native window (ANativeWindow*)
-    /// * On Linux, this is the native window (Window)
-    void* pNativeWndHandle DEFAULT_INITIALIZER(nullptr);
-
-#if PLATFORM_LINUX
-    /// For linux platform only, this is the pointer to the display
-    void* pDisplay         DEFAULT_INITIALIZER(nullptr);
-#endif
+	/// Native window wrapper
+	NativeWindow Window;
 };
 typedef struct EngineGLCreateInfo EngineGLCreateInfo;
 

--- a/Graphics/GraphicsEngineOpenGL/src/GLContextAndroid.cpp
+++ b/Graphics/GraphicsEngineOpenGL/src/GLContextAndroid.cpp
@@ -237,7 +237,7 @@ GLContext::GLContext(const EngineGLCreateInfo& InitAttribs, DeviceCaps& deviceCa
     major_version_(0),
     minor_version_(0)
 {
-    auto* NativeWindow = reinterpret_cast<ANativeWindow*>(InitAttribs.pNativeWndHandle);
+    auto* NativeWindow = reinterpret_cast<ANativeWindow*>(InitAttribs.Window.pAWindow);
     Init(NativeWindow);
 
     FillDeviceCaps(deviceCaps);

--- a/Graphics/GraphicsEngineOpenGL/src/GLContextIOS.mm
+++ b/Graphics/GraphicsEngineOpenGL/src/GLContextIOS.mm
@@ -46,7 +46,7 @@ namespace Diligent
         //Or better yet, use the GL3 way to get the version number
         glGetIntegerv( GL_MAJOR_VERSION, &MajorVersion );
         glGetIntegerv( GL_MINOR_VERSION, &MinorVersion );
-        LOG_INFO_MESSAGE(Info.pNativeWndHandle != nullptr ? "Initialized OpenGLES " : "Attached to OpenGLES ", MajorVersion, '.', MinorVersion, " context (", GLVersionString, ", ", GLRenderer, ')');
+        LOG_INFO_MESSAGE(Info.Window.pNSView != nullptr ? "Initialized OpenGLES " : "Attached to OpenGLES ", MajorVersion, '.', MinorVersion, " context (", GLVersionString, ", ", GLRenderer, ')');
 
         // Under the standard filtering rules for cubemaps, filtering does not work across faces of the cubemap. 
         // This results in a seam across the faces of a cubemap. This was a hardware limitation in the past, but 

--- a/Graphics/GraphicsEngineOpenGL/src/GLContextLinux.cpp
+++ b/Graphics/GraphicsEngineOpenGL/src/GLContextLinux.cpp
@@ -87,8 +87,8 @@ void openglCallbackFunction(GLenum        source,
 
 GLContext::GLContext(const EngineGLCreateInfo& InitAttribs, DeviceCaps& deviceCaps, const struct SwapChainDesc* /*pSCDesc*/) :
     m_Context(0),
-    m_pNativeWindow(InitAttribs.pNativeWndHandle),
-    m_pDisplay(InitAttribs.pDisplay)
+    m_pNativeWindow(InitAttribs.Window.pWindow),
+    m_pDisplay(InitAttribs.Window.pDisplay)
 {
     auto CurrentCtx = glXGetCurrentContext();
     if (CurrentCtx == 0)
@@ -101,7 +101,7 @@ GLContext::GLContext(const EngineGLCreateInfo& InitAttribs, DeviceCaps& deviceCa
     if (GLEW_OK != err)
         LOG_ERROR_AND_THROW("Failed to initialize GLEW");
 
-    if (InitAttribs.pNativeWndHandle != nullptr && InitAttribs.pDisplay != nullptr)
+    if (InitAttribs.Window.pWindow != nullptr && InitAttribs.Window.pDisplay != nullptr)
     {
         //glXSwapIntervalEXT(0);
 
@@ -127,7 +127,7 @@ GLContext::GLContext(const EngineGLCreateInfo& InitAttribs, DeviceCaps& deviceCa
     //Or better yet, use the GL3 way to get the version number
     glGetIntegerv(GL_MAJOR_VERSION, &MajorVersion);
     glGetIntegerv(GL_MINOR_VERSION, &MinorVersion);
-    LOG_INFO_MESSAGE(InitAttribs.pNativeWndHandle != nullptr ? "Initialized OpenGL " : "Attached to OpenGL ", MajorVersion, '.', MinorVersion, " context (", GLVersionString, ", ", GLRenderer, ')');
+    LOG_INFO_MESSAGE(InitAttribs.Window.pWindow != nullptr ? "Initialized OpenGL " : "Attached to OpenGL ", MajorVersion, '.', MinorVersion, " context (", GLVersionString, ", ", GLRenderer, ')');
 
     // Under the standard filtering rules for cubemaps, filtering does not work across faces of the cubemap.
     // This results in a seam across the faces of a cubemap. This was a hardware limitation in the past, but

--- a/Graphics/GraphicsEngineOpenGL/src/GLContextMacOS.mm
+++ b/Graphics/GraphicsEngineOpenGL/src/GLContextMacOS.mm
@@ -74,7 +74,7 @@ namespace Diligent
         //Or better yet, use the GL3 way to get the version number
         glGetIntegerv( GL_MAJOR_VERSION, &MajorVersion );
         glGetIntegerv( GL_MINOR_VERSION, &MinorVersion );
-        LOG_INFO_MESSAGE(InitAttribs.pNativeWndHandle != nullptr ? "Initialized OpenGL " : "Attached to OpenGL ", MajorVersion, '.', MinorVersion, " context (", GLVersionString, ", ", GLRenderer, ')');
+        LOG_INFO_MESSAGE(InitAttribs.Window.pNSWindow != nullptr ? "Initialized OpenGL " : "Attached to OpenGL ", MajorVersion, '.', MinorVersion, " context (", GLVersionString, ", ", GLRenderer, ')');
 
         // Under the standard filtering rules for cubemaps, filtering does not work across faces of the cubemap. 
         // This results in a seam across the faces of a cubemap. This was a hardware limitation in the past, but 

--- a/Graphics/GraphicsEngineOpenGL/src/GLContextWindows.cpp
+++ b/Graphics/GraphicsEngineOpenGL/src/GLContextWindows.cpp
@@ -104,9 +104,9 @@ GLContext::GLContext(const EngineGLCreateInfo& InitAttribs, DeviceCaps& deviceCa
     m_WindowHandleToDeviceContext{0}
 {
     Int32 MajorVersion = 0, MinorVersion = 0;
-    if (InitAttribs.pNativeWndHandle != nullptr)
+    if (InitAttribs.Window.hWnd != nullptr)
     {
-        HWND hWnd = reinterpret_cast<HWND>(InitAttribs.pNativeWndHandle);
+        HWND hWnd = reinterpret_cast<HWND>(InitAttribs.Window.hWnd);
 
         // See http://www.opengl.org/wiki/Tutorial:_OpenGL_3.1_The_First_Triangle_(C%2B%2B/Win)
         //     http://www.opengl.org/wiki/Creating_an_OpenGL_Context_(WGL)
@@ -273,7 +273,7 @@ GLContext::GLContext(const EngineGLCreateInfo& InitAttribs, DeviceCaps& deviceCa
     //Or better yet, use the GL3 way to get the version number
     glGetIntegerv(GL_MAJOR_VERSION, &MajorVersion);
     glGetIntegerv(GL_MINOR_VERSION, &MinorVersion);
-    LOG_INFO_MESSAGE(InitAttribs.pNativeWndHandle != nullptr ? "Initialized OpenGL " : "Attached to OpenGL ", MajorVersion, '.', MinorVersion, " context (", GLVersionString, ')');
+    LOG_INFO_MESSAGE(InitAttribs.Window.hWnd != nullptr ? "Initialized OpenGL " : "Attached to OpenGL ", MajorVersion, '.', MinorVersion, " context (", GLVersionString, ')');
 
     // Under the standard filtering rules for cubemaps, filtering does not work across faces of the cubemap.
     // This results in a seam across the faces of a cubemap. This was a hardware limitation in the past, but

--- a/Graphics/GraphicsEngineOpenGL/src/SwapChainGLIOS.mm
+++ b/Graphics/GraphicsEngineOpenGL/src/SwapChainGLIOS.mm
@@ -43,7 +43,7 @@ SwapChainGLIOS::SwapChainGLIOS(IReferenceCounters*          pRefCounters,
     m_DepthRenderBuffer(false),
     m_DefaultFBO(false)
 {
-    m_CALayer = InitAttribs.pNativeWndHandle;
+    m_CALayer = InitAttribs.Window.pNSView;
     InitRenderBuffers(true, m_SwapChainDesc.Width, m_SwapChainDesc.Height);
     CreateDummyBuffers(m_pRenderDevice.RawPtr<RenderDeviceGLImpl>());
 }

--- a/Graphics/GraphicsEngineOpenGL/src/SwapChainGLImpl.cpp
+++ b/Graphics/GraphicsEngineOpenGL/src/SwapChainGLImpl.cpp
@@ -48,14 +48,14 @@ SwapChainGLImpl::SwapChainGLImpl(IReferenceCounters*       pRefCounters,
 // clang-format on
 {
 #if PLATFORM_WIN32
-    HWND hWnd = reinterpret_cast<HWND>(InitAttribs.pNativeWndHandle);
+    HWND hWnd = reinterpret_cast<HWND>(InitAttribs.Window.hWnd);
     RECT rc;
     GetClientRect(hWnd, &rc);
     m_SwapChainDesc.Width  = rc.right - rc.left;
     m_SwapChainDesc.Height = rc.bottom - rc.top;
 #elif PLATFORM_LINUX
-    auto wnd     = static_cast<Window>(reinterpret_cast<size_t>(InitAttribs.pNativeWndHandle));
-    auto display = reinterpret_cast<Display*>(InitAttribs.pDisplay);
+    auto wnd     = static_cast<Window>(reinterpret_cast<size_t>(InitAttribs.Window.pWindow));
+    auto display = reinterpret_cast<Display*>(InitAttribs.Window.pDisplay);
 
     XWindowAttributes XWndAttribs;
     XGetWindowAttributes(display, wnd, &XWndAttribs);

--- a/Platforms/Android/CMakeLists.txt
+++ b/Platforms/Android/CMakeLists.txt
@@ -7,6 +7,7 @@ set(INTERFACE
     interface/AndroidFileSystem.hpp
     interface/AndroidPlatformDefinitions.h
     interface/AndroidPlatformMisc.hpp
+    interface/AndroidNativeWindow.hpp
 )
 
 set(SOURCE 

--- a/Platforms/Android/interface/AndroidNativeWindow.hpp
+++ b/Platforms/Android/interface/AndroidNativeWindow.hpp
@@ -25,49 +25,15 @@
  *  of the possibility of such damages.
  */
 
-#include "TestingEnvironment.hpp"
+#pragma once
 
-#ifndef NOMINMAX
-#    define NOMINMAX
-#endif
-#include <Windows.h>
+#include "../../../Primitives/interface/CommonDefinitions.h"
 
-namespace Diligent
+DILIGENT_BEGIN_NAMESPACE(Diligent)
+
+struct AndroidNativeWindow
 {
+    void* pAWindow DEFAULT_INITIALIZER(nullptr);
+};
 
-namespace Testing
-{
-
-NativeWindow TestingEnvironment::CreateNativeWindow()
-{
-#ifdef UNICODE
-    const auto* const WindowClassName = L"SampleApp";
-#else
-    const auto* const WindowClassName = "SampleApp";
-#endif
-    // Register window class
-    HINSTANCE instance = NULL;
-
-    WNDCLASSEX wcex = {sizeof(WNDCLASSEX), CS_HREDRAW | CS_VREDRAW, DefWindowProc,
-                       0L, 0L, instance, NULL, NULL, NULL, NULL, WindowClassName, NULL};
-    RegisterClassEx(&wcex);
-
-    LONG WindowWidth  = 512;
-    LONG WindowHeight = 512;
-    RECT rc           = {0, 0, WindowWidth, WindowHeight};
-    AdjustWindowRect(&rc, WS_OVERLAPPEDWINDOW, FALSE);
-    HWND wnd = CreateWindowA("SampleApp", "Dummy Window",
-                             WS_OVERLAPPEDWINDOW, CW_USEDEFAULT, CW_USEDEFAULT,
-                             rc.right - rc.left, rc.bottom - rc.top, NULL, NULL, instance, NULL);
-    if (wnd == NULL)
-        LOG_ERROR_AND_THROW("Unable to create a window");
-
-    NativeWindow Window;
-    Window.hWnd = wnd;
-
-    return Window;
-}
-
-} // namespace Testing
-
-} // namespace Diligent
+DILIGENT_END_NAMESPACE // namespace Diligent

--- a/Platforms/Apple/CMakeLists.txt
+++ b/Platforms/Apple/CMakeLists.txt
@@ -2,12 +2,19 @@ cmake_minimum_required (VERSION 3.6)
 
 project(Diligent-ApplePlatform CXX)
 
+if(PLATFORM_MACOS)
+    set(APPLE_NATIVE_WINDOW_H interface/MacOSNativeWindow.hpp)
+elseif(PLATFORM_IOS)
+    set(APPLE_NATIVE_WINDOW_H interface/IOSNativeWindow.hpp)
+endif()
+
 set(INTERFACE
     interface/CFObjectWrapper.hpp
     interface/AppleDebug.hpp
     interface/AppleFileSystem.hpp
     interface/ApplePlatformDefinitions.h
     interface/ApplePlatformMisc.hpp
+    ${APPLE_NATIVE_WINDOW_H}
 )
 
 set(SOURCE

--- a/Platforms/Apple/interface/IOSNativeWindow.hpp
+++ b/Platforms/Apple/interface/IOSNativeWindow.hpp
@@ -25,49 +25,15 @@
  *  of the possibility of such damages.
  */
 
-#include "TestingEnvironment.hpp"
+#pragma once
 
-#ifndef NOMINMAX
-#    define NOMINMAX
-#endif
-#include <Windows.h>
+#include "../../../Primitives/interface/CommonDefinitions.h"
 
-namespace Diligent
+DILIGENT_BEGIN_NAMESPACE(Diligent)
+
+struct IOSNativeWindow
 {
+    void* pNSView DEFAULT_INITIALIZER(nullptr);
+};
 
-namespace Testing
-{
-
-NativeWindow TestingEnvironment::CreateNativeWindow()
-{
-#ifdef UNICODE
-    const auto* const WindowClassName = L"SampleApp";
-#else
-    const auto* const WindowClassName = "SampleApp";
-#endif
-    // Register window class
-    HINSTANCE instance = NULL;
-
-    WNDCLASSEX wcex = {sizeof(WNDCLASSEX), CS_HREDRAW | CS_VREDRAW, DefWindowProc,
-                       0L, 0L, instance, NULL, NULL, NULL, NULL, WindowClassName, NULL};
-    RegisterClassEx(&wcex);
-
-    LONG WindowWidth  = 512;
-    LONG WindowHeight = 512;
-    RECT rc           = {0, 0, WindowWidth, WindowHeight};
-    AdjustWindowRect(&rc, WS_OVERLAPPEDWINDOW, FALSE);
-    HWND wnd = CreateWindowA("SampleApp", "Dummy Window",
-                             WS_OVERLAPPEDWINDOW, CW_USEDEFAULT, CW_USEDEFAULT,
-                             rc.right - rc.left, rc.bottom - rc.top, NULL, NULL, instance, NULL);
-    if (wnd == NULL)
-        LOG_ERROR_AND_THROW("Unable to create a window");
-
-    NativeWindow Window;
-    Window.hWnd = wnd;
-
-    return Window;
-}
-
-} // namespace Testing
-
-} // namespace Diligent
+DILIGENT_END_NAMESPACE // namespace Diligent

--- a/Platforms/Apple/interface/MacOSNativeWindow.hpp
+++ b/Platforms/Apple/interface/MacOSNativeWindow.hpp
@@ -25,49 +25,15 @@
  *  of the possibility of such damages.
  */
 
-#include "TestingEnvironment.hpp"
+#pragma once
 
-#ifndef NOMINMAX
-#    define NOMINMAX
-#endif
-#include <Windows.h>
+#include "../../../Primitives/interface/CommonDefinitions.h"
 
-namespace Diligent
+DILIGENT_BEGIN_NAMESPACE(Diligent)
+
+struct MacOSNativeWindow
 {
+    void* pNSWindow DEFAULT_INITIALIZER(nullptr);
+};
 
-namespace Testing
-{
-
-NativeWindow TestingEnvironment::CreateNativeWindow()
-{
-#ifdef UNICODE
-    const auto* const WindowClassName = L"SampleApp";
-#else
-    const auto* const WindowClassName = "SampleApp";
-#endif
-    // Register window class
-    HINSTANCE instance = NULL;
-
-    WNDCLASSEX wcex = {sizeof(WNDCLASSEX), CS_HREDRAW | CS_VREDRAW, DefWindowProc,
-                       0L, 0L, instance, NULL, NULL, NULL, NULL, WindowClassName, NULL};
-    RegisterClassEx(&wcex);
-
-    LONG WindowWidth  = 512;
-    LONG WindowHeight = 512;
-    RECT rc           = {0, 0, WindowWidth, WindowHeight};
-    AdjustWindowRect(&rc, WS_OVERLAPPEDWINDOW, FALSE);
-    HWND wnd = CreateWindowA("SampleApp", "Dummy Window",
-                             WS_OVERLAPPEDWINDOW, CW_USEDEFAULT, CW_USEDEFAULT,
-                             rc.right - rc.left, rc.bottom - rc.top, NULL, NULL, instance, NULL);
-    if (wnd == NULL)
-        LOG_ERROR_AND_THROW("Unable to create a window");
-
-    NativeWindow Window;
-    Window.hWnd = wnd;
-
-    return Window;
-}
-
-} // namespace Testing
-
-} // namespace Diligent
+DILIGENT_END_NAMESPACE // namespace Diligent

--- a/Platforms/CMakeLists.txt
+++ b/Platforms/CMakeLists.txt
@@ -10,6 +10,7 @@ set(PLATFORM_INTERFACE_HEADERS
 	../interface/PlatformDebug.hpp
 	../interface/PlatformDefinitions.h
 	../interface/PlatformMisc.hpp
+	../interface/NativeWindow.h
 )
 
 add_subdirectory(Basic)

--- a/Platforms/Linux/CMakeLists.txt
+++ b/Platforms/Linux/CMakeLists.txt
@@ -7,6 +7,7 @@ set(INTERFACE
     interface/LinuxFileSystem.hpp
     interface/LinuxPlatformDefinitions.h
     interface/LinuxPlatformMisc.hpp
+    interface/LinuxNativeWindow.hpp
 )
 
 set(SOURCE 

--- a/Platforms/Linux/interface/LinuxNativeWindow.hpp
+++ b/Platforms/Linux/interface/LinuxNativeWindow.hpp
@@ -25,49 +25,16 @@
  *  of the possibility of such damages.
  */
 
-#include "TestingEnvironment.hpp"
+#pragma once
 
-#ifndef NOMINMAX
-#    define NOMINMAX
-#endif
-#include <Windows.h>
+#include "../../../Primitives/interface/CommonDefinitions.h"
 
-namespace Diligent
+DILIGENT_BEGIN_NAMESPACE(Diligent)
+
+struct LinuxNativeWindow
 {
+    void* pDisplay DEFAULT_INITIALIZER(nullptr);
+    void* pWindow  DEFAULT_INITIALIZER(nullptr);
+};
 
-namespace Testing
-{
-
-NativeWindow TestingEnvironment::CreateNativeWindow()
-{
-#ifdef UNICODE
-    const auto* const WindowClassName = L"SampleApp";
-#else
-    const auto* const WindowClassName = "SampleApp";
-#endif
-    // Register window class
-    HINSTANCE instance = NULL;
-
-    WNDCLASSEX wcex = {sizeof(WNDCLASSEX), CS_HREDRAW | CS_VREDRAW, DefWindowProc,
-                       0L, 0L, instance, NULL, NULL, NULL, NULL, WindowClassName, NULL};
-    RegisterClassEx(&wcex);
-
-    LONG WindowWidth  = 512;
-    LONG WindowHeight = 512;
-    RECT rc           = {0, 0, WindowWidth, WindowHeight};
-    AdjustWindowRect(&rc, WS_OVERLAPPEDWINDOW, FALSE);
-    HWND wnd = CreateWindowA("SampleApp", "Dummy Window",
-                             WS_OVERLAPPEDWINDOW, CW_USEDEFAULT, CW_USEDEFAULT,
-                             rc.right - rc.left, rc.bottom - rc.top, NULL, NULL, instance, NULL);
-    if (wnd == NULL)
-        LOG_ERROR_AND_THROW("Unable to create a window");
-
-    NativeWindow Window;
-    Window.hWnd = wnd;
-
-    return Window;
-}
-
-} // namespace Testing
-
-} // namespace Diligent
+DILIGENT_END_NAMESPACE // namespace Diligent

--- a/Platforms/UWP/CMakeLists.txt
+++ b/Platforms/UWP/CMakeLists.txt
@@ -6,6 +6,7 @@ set(INTERFACE
     interface/UWPDebug.hpp
     interface/UWPFileSystem.hpp
     interface/UWPDefinitions.h
+    interface/UWPNativeWindow.hpp
     ../Win32/interface/Win32Atomics.hpp
 )
 

--- a/Platforms/UWP/interface/UWPNativeWindow.hpp
+++ b/Platforms/UWP/interface/UWPNativeWindow.hpp
@@ -25,49 +25,15 @@
  *  of the possibility of such damages.
  */
 
-#include "TestingEnvironment.hpp"
+#pragma once
 
-#ifndef NOMINMAX
-#    define NOMINMAX
-#endif
-#include <Windows.h>
+#include "../../../Primitives/interface/CommonDefinitions.h"
 
-namespace Diligent
+DILIGENT_BEGIN_NAMESPACE(Diligent)
+
+struct UWPNativeWindow
 {
+    void* pWindow DEFAULT_INITIALIZER(nullptr);
+};
 
-namespace Testing
-{
-
-NativeWindow TestingEnvironment::CreateNativeWindow()
-{
-#ifdef UNICODE
-    const auto* const WindowClassName = L"SampleApp";
-#else
-    const auto* const WindowClassName = "SampleApp";
-#endif
-    // Register window class
-    HINSTANCE instance = NULL;
-
-    WNDCLASSEX wcex = {sizeof(WNDCLASSEX), CS_HREDRAW | CS_VREDRAW, DefWindowProc,
-                       0L, 0L, instance, NULL, NULL, NULL, NULL, WindowClassName, NULL};
-    RegisterClassEx(&wcex);
-
-    LONG WindowWidth  = 512;
-    LONG WindowHeight = 512;
-    RECT rc           = {0, 0, WindowWidth, WindowHeight};
-    AdjustWindowRect(&rc, WS_OVERLAPPEDWINDOW, FALSE);
-    HWND wnd = CreateWindowA("SampleApp", "Dummy Window",
-                             WS_OVERLAPPEDWINDOW, CW_USEDEFAULT, CW_USEDEFAULT,
-                             rc.right - rc.left, rc.bottom - rc.top, NULL, NULL, instance, NULL);
-    if (wnd == NULL)
-        LOG_ERROR_AND_THROW("Unable to create a window");
-
-    NativeWindow Window;
-    Window.hWnd = wnd;
-
-    return Window;
-}
-
-} // namespace Testing
-
-} // namespace Diligent
+DILIGENT_END_NAMESPACE // namespace Diligent

--- a/Platforms/Win32/CMakeLists.txt
+++ b/Platforms/Win32/CMakeLists.txt
@@ -8,6 +8,7 @@ set(INTERFACE
     interface/Win32FileSystem.hpp
     interface/Win32PlatformDefinitions.h
     interface/Win32PlatformMisc.hpp
+    interface/Win32NativeWindow.hpp
 )
 
 set(SOURCE 

--- a/Platforms/Win32/interface/Win32NativeWindow.hpp
+++ b/Platforms/Win32/interface/Win32NativeWindow.hpp
@@ -25,49 +25,15 @@
  *  of the possibility of such damages.
  */
 
-#include "TestingEnvironment.hpp"
+#pragma once
 
-#ifndef NOMINMAX
-#    define NOMINMAX
-#endif
-#include <Windows.h>
+#include "../../../Primitives/interface/CommonDefinitions.h"
 
-namespace Diligent
+DILIGENT_BEGIN_NAMESPACE(Diligent)
+
+struct Win32NativeWindow
 {
+    void* hWnd DEFAULT_INITIALIZER(nullptr);
+};
 
-namespace Testing
-{
-
-NativeWindow TestingEnvironment::CreateNativeWindow()
-{
-#ifdef UNICODE
-    const auto* const WindowClassName = L"SampleApp";
-#else
-    const auto* const WindowClassName = "SampleApp";
-#endif
-    // Register window class
-    HINSTANCE instance = NULL;
-
-    WNDCLASSEX wcex = {sizeof(WNDCLASSEX), CS_HREDRAW | CS_VREDRAW, DefWindowProc,
-                       0L, 0L, instance, NULL, NULL, NULL, NULL, WindowClassName, NULL};
-    RegisterClassEx(&wcex);
-
-    LONG WindowWidth  = 512;
-    LONG WindowHeight = 512;
-    RECT rc           = {0, 0, WindowWidth, WindowHeight};
-    AdjustWindowRect(&rc, WS_OVERLAPPEDWINDOW, FALSE);
-    HWND wnd = CreateWindowA("SampleApp", "Dummy Window",
-                             WS_OVERLAPPEDWINDOW, CW_USEDEFAULT, CW_USEDEFAULT,
-                             rc.right - rc.left, rc.bottom - rc.top, NULL, NULL, instance, NULL);
-    if (wnd == NULL)
-        LOG_ERROR_AND_THROW("Unable to create a window");
-
-    NativeWindow Window;
-    Window.hWnd = wnd;
-
-    return Window;
-}
-
-} // namespace Testing
-
-} // namespace Diligent
+DILIGENT_END_NAMESPACE // namespace Diligent

--- a/Platforms/interface/NativeWindow.h
+++ b/Platforms/interface/NativeWindow.h
@@ -1,0 +1,90 @@
+/*
+ *  Copyright 2019-2020 Diligent Graphics LLC
+ *  Copyright 2015-2019 Egor Yusov
+ *  
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  In no event and under no legal theory, whether in tort (including negligence), 
+ *  contract, or otherwise, unless required by applicable law (such as deliberate 
+ *  and grossly negligent acts) or agreed to in writing, shall any Contributor be
+ *  liable for any damages, including any direct, indirect, special, incidental, 
+ *  or consequential damages of any character arising as a result of this License or 
+ *  out of the use or inability to use the software (including but not limited to damages 
+ *  for loss of goodwill, work stoppage, computer failure or malfunction, or any and 
+ *  all other commercial damages or losses), even if such Contributor has been advised 
+ *  of the possibility of such damages.
+ */
+
+#pragma once
+
+#include "PlatformDefinitions.h"
+
+#if PLATFORM_WIN32
+
+#    include "../Win32/interface/Win32NativeWindow.hpp"
+
+#elif PLATFORM_UNIVERSAL_WINDOWS
+
+#    include "../UWP/interface/UWPNativeWindow.hpp"
+
+#elif PLATFORM_ANDROID
+
+#    include "../Android/interface/AndroidNativeWindow.hpp"
+
+#elif PLATFORM_LINUX
+
+#    include "../Linux/interface/LinuxNativeWindow.hpp"
+
+#elif PLATFORM_MACOS
+
+#    include "../Apple/interface/MacOSNativeWindow.hpp"
+
+#elif PLATFORM_IOS
+
+#    include "../Apple/interface/IOSNativeWindow.hpp"
+
+#else
+#    error Unknown platform. Please define one of the following macros as 1:  PLATFORM_WIN32, PLATFORM_UNIVERSAL_WINDOWS, PLATFORM_ANDROID, PLATFORM_LINUX, PLATFORM_MACOS, PLATFORM_IOS.
+#endif
+
+DILIGENT_BEGIN_NAMESPACE(Diligent)
+
+#if PLATFORM_WIN32
+
+typedef struct Win32NativeWindow NativeWindow;
+
+#elif PLATFORM_UNIVERSAL_WINDOWS
+
+typedef struct UWPNativeWindow NativeWindow;
+
+#elif PLATFORM_ANDROID
+
+typedef struct AndroidNativeWindow NativeWindow;
+
+#elif PLATFORM_LINUX
+
+typedef struct LinuxNativeWindow NativeWindow;
+
+#elif PLATFORM_MACOS
+
+typedef struct MacOSNativeWindow NativeWindow;
+
+#elif PLATFORM_IOS
+
+typedef struct IOSNativeWindow NativeWindow;
+
+#else
+#    error Unknown platform. Please define one of the following macros as 1:  PLATFORM_WIN32, PLATFORM_UNIVERSAL_WINDOWS, PLATFORM_ANDROID, PLATFORM_LINUX, PLATFORM_MACOS, PLATFORM_IOS.
+#endif
+
+DILIGENT_END_NAMESPACE // namespace Diligent

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ void InitializeDiligentEngine(HWND NativeWindowHandle)
 #endif
         auto* pFactoryOpenGL = GetEngineFactoryOpenGL();
         EngineGLCreateInfo EngineCI;
-        EngineCI.pNativeWndHandle = NativeWindowHandle;
+        EngineCI.Window.hWnd = NativeWindowHandle;
         pFactoryOpenGL->CreateDeviceAndSwapChainGL(
             EngineCI, &m_pDevice, &m_pImmediateContext, SCDesc, &m_pSwapChain);
     }
@@ -217,7 +217,7 @@ On Android, you can only create OpenGLES device. The following code snippet show
 ```cpp
 auto* pFactoryOpenGL = GetEngineFactoryOpenGL();
 EngineGLCreateInfo EngineCI;
-EngineCI.pNativeWndHandle = NativeWindowHandle;
+EngineCI.NativeWindow.pAWindow = NativeWindowHandle;
 pFactoryOpenGL->CreateDeviceAndSwapChainGL(
     EngineCI, &m_pDevice, &m_pContext, SCDesc, &m_pSwapChain);
 IRenderDeviceGLES *pRenderDeviceOpenGLES;

--- a/ReleaseHistory.md
+++ b/ReleaseHistory.md
@@ -1,5 +1,6 @@
 ## Current Progress
 
+* Added `NativeWindow` wrapper and replaced `pNativeWndHandle` and `pDisplay` members with it in `EngineGLCreateInfo` (API Version 240053)
 * Added C Interface (API Version 240052)
 
 ## v2.4.d

--- a/Tests/DiligentCoreAPITest/include/TestingEnvironment.hpp
+++ b/Tests/DiligentCoreAPITest/include/TestingEnvironment.hpp
@@ -34,6 +34,7 @@
 #include "RefCntAutoPtr.hpp"
 #include "SwapChain.h"
 #include "GraphicsTypesOutputInserters.hpp"
+#include "NativeWindow.h"
 
 #include "gtest/gtest.h"
 
@@ -46,16 +47,8 @@ namespace Testing
 class TestingEnvironment : public ::testing::Environment
 {
 public:
-    struct NativeWindow
-    {
-        void* NativeWindowHandle = nullptr;
-#if PLATFORM_LINUX
-        void* Display = nullptr;
-#endif
-    };
-
-
     TestingEnvironment(RENDER_DEVICE_TYPE deviceType, ADAPTER_TYPE AdapterType, const SwapChainDesc& SCDesc);
+
     ~TestingEnvironment() override;
 
     // Override this to define how to set up the environment.

--- a/Tests/DiligentCoreAPITest/src/Linux/TestingEnvironmentLinux.cpp
+++ b/Tests/DiligentCoreAPITest/src/Linux/TestingEnvironmentLinux.cpp
@@ -33,9 +33,9 @@ namespace Diligent
 namespace Testing
 {
 
-TestingEnvironment::NativeWindow TestingEnvironment::CreateNativeWindow()
+NativeWindow TestingEnvironment::CreateNativeWindow()
 {
-    return TestingEnvironment::NativeWindow{};
+    return NativeWindow{};
 }
 
 } // namespace Testing

--- a/Tests/DiligentCoreAPITest/src/MacOS/TestingEnvironmentMacOS.cpp
+++ b/Tests/DiligentCoreAPITest/src/MacOS/TestingEnvironmentMacOS.cpp
@@ -33,9 +33,9 @@ namespace Diligent
 namespace Testing
 {
 
-TestingEnvironment::NativeWindow TestingEnvironment::CreateNativeWindow()
+NativeWindow TestingEnvironment::CreateNativeWindow()
 {
-    return TestingEnvironment::NativeWindow{};
+    return NativeWindow{};
 }
 
 } // namespace Testing

--- a/Tests/DiligentCoreAPITest/src/TestingEnvironment.cpp
+++ b/Tests/DiligentCoreAPITest/src/TestingEnvironment.cpp
@@ -269,14 +269,12 @@ TestingEnvironment::TestingEnvironment(RENDER_DEVICE_TYPE deviceType, ADAPTER_TY
 #    endif
             auto* pFactoryOpenGL = GetEngineFactoryOpenGL();
 
-            auto NativeWnd = CreateNativeWindow();
+            NativeWindow Window = CreateNativeWindow();
 
             EngineGLCreateInfo CreateInfo;
             CreateInfo.DebugMessageCallback = MessageCallback;
-            CreateInfo.pNativeWndHandle     = NativeWnd.NativeWindowHandle;
-#    if PLATFORM_LINUX
-            CreateInfo.pDisplay = NativeWnd.Display;
-#    endif
+            CreateInfo.Window               = Window;
+
             if (NumDeferredCtx != 0)
             {
                 LOG_ERROR_MESSAGE("Deferred contexts are not supported in OpenGL mode");


### PR DESCRIPTION
Use NativeHandle in tests

There are a few things that I'm still considering.

1. The terminology for iOS is view rather than window but I kept it as WindowHandle rather than ViewHandle for consistency.

2. This abstraction can be used in the engine creation descriptor struct for OGL. However, since I am not able to test all platforms I am not comfortable making this change. 

I believe I need to forward declare HWND in Win32NativeWindow.h to use HWND instead of void* for the type. Including Windows.h there is problematic.