### PR TITLE
Add CMake option to statically link with MoltenVK

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,7 +130,13 @@ elseif(PLATFORM_IOS)
         # iOS.toolchain.cmake currently configures cmake to only search iOS SDK for libraries,
         # thus find_library will be unable to find MoltenVK in VulkanSDK
         # find_library(MoltenVK_LIBRARY MoltenVK PATHS "${VULKAN_SDK}/MoltenVK/iOS/dynamic")
-        set(MoltenVK_LIBRARY "${VULKAN_SDK}/MoltenVK/iOS/dynamic/libMoltenVK.dylib" CACHE INTERNAL "MoltenVK library")
+        option(DILIGENT_MOLTENVK_LINK_STATIC "Link with MoltenVK static library" OFF)
+        if(${DILIGENT_MOLTENVK_LINK_STATIC})
+            set(MoltenVK_LIBRARY "${VULKAN_SDK}/MoltenVK/iOS/static/libMoltenVK.a" CACHE INTERNAL "MoltenVK library")
+        else()
+            set(MoltenVK_LIBRARY "${VULKAN_SDK}/MoltenVK/iOS/dynamic/libMoltenVK.dylib" CACHE INTERNAL "MoltenVK library")
+        endif()
+
         if(EXISTS ${MoltenVK_LIBRARY})
             set(VULKAN_SUPPORTED TRUE CACHE INTERNAL "Vulkan is enabled through MoltenVK on iOS platform")
         else()


### PR DESCRIPTION
Hi,

We followed the documentation to add MoltenVK's dylib into our Xcode project and that worked like a charm 👍 

Yet, since our project has a particular setup, and that we build a framework which is then embedded into a final Xcode application, we want to ship MoltenVK with our framework. This, unless mistaken, seems not easily feasible as of today.

We figured that linking with MoltenVK's static library actually does the job pretty well, and might be an acceptable alternative in our situation.

So, in this pull request, I'm adding an optional `DILIGENT_MOLTENVK_LINK_STATIC` option to indicate that we wish to statically link against MoltenVK. Hence this should not impact existing projects. Possibly, this option might be of service in other projects than ours.

