### PR TITLE
Fallback to GLX_MESA_swap_control if GLX_EXT_swap_control isn't supported

### DIFF
--- a/Graphics/GraphicsEngineOpenGL/src/GLContextLinux.cpp
+++ b/Graphics/GraphicsEngineOpenGL/src/GLContextLinux.cpp
@@ -166,6 +166,12 @@ void GLContext::SwapBuffers(int SwapInterval)
         {
             glXSwapIntervalEXT(display, wnd, SwapInterval);
         }
+#    if GLX_MESA_swap_control
+        else if (glXSwapIntervalMESA != nullptr)
+        {
+            glXSwapIntervalMESA(SwapInterval);
+        }
+#    endif
 #endif
         glXSwapBuffers(display, wnd);
     }


### PR DESCRIPTION
Tested with Radeon RX 570 Series (POLARIS10, DRM 3.35.0, 5.4.33-3-lts, LLVM 10.0.0)