### PR TITLE
VK_LAYER_LUNARG_standard_validation deprecated

### DIFF
--- a/Graphics/GraphicsEngineVulkan/include/VulkanUtilities/VulkanDebug.hpp
+++ b/Graphics/GraphicsEngineVulkan/include/VulkanUtilities/VulkanDebug.hpp
@@ -12,7 +12,7 @@ namespace VulkanUtilities
 // On desktop the LunarG loaders exposes a meta layer that contains all layers
 static constexpr const char* ValidationLayerNames[] = 
 {
-    "VK_LAYER_LUNARG_standard_validation"
+    "VK_LAYER_KHRONOS_validation"
 };
 #else
 // On Android we need to explicitly select all layers


### PR DESCRIPTION
https://vulkan.lunarg.com/doc/view/1.0.57.0/windows/validation_layers.html VK_LAYER_LUNARG_standard_validation is deprecated use VK_LAYER_KHRONOS_validation instead.