### PR TITLE
Validate format won't crash if it cannot load the provided binary

### DIFF
--- a/BuildTools/FormatValidation/validate_format_linux.sh
+++ b/BuildTools/FormatValidation/validate_format_linux.sh
@@ -1,7 +1,35 @@
 #!/bin/bash
-python clang-format-validate.py --clang-format-executable ./clang-format_linux_10.0.0 \
--r ../../Common ../../Graphics ../../Platforms ../../Primitives ../../Tests \
---exclude ../../Graphics/HLSL2GLSLConverterLib/include/GLSLDefinitions.h \
---exclude ../../Graphics/HLSL2GLSLConverterLib/include/GLSLDefinitions_inc.h \
---exclude ../../Graphics/GraphicsEngineVulkan/shaders/GenerateMipsCS_inc.h \
---exclude ../../Tests/DiligentCoreAPITest/assets/*
+
+## Set the shipped BIN
+BIN="./clang-format_linux_10.0.0"
+## ...or use the find command to avoid maintaining
+#BIN=$(find . -name 'clang-format_linux*')
+
+## Set to anything but 0 to force skip format validation
+SKIP=0
+
+if [ "$SKIP" -eq 0 ]; then
+  ## Try to get the version
+  eval "$BIN" --version 2> /dev/null  
+  if [ $? -ne 0 ]; then
+    ## Try to get a system installed clang-format
+    BIN=$(which clang-format 2> /dev/null)
+    if [ $? -ne 0 ]; then
+      echo "WARNING: skipping format validation as no suitable executable was found"
+      SKIP=1
+    else
+      echo "WARNING: could not load the integrated format validator binary, but a system one was found."
+      echo "   Should it cause any issue due to versioning, you can skip validation by setting \"SKIP=1\""
+      echo "   in: DiligentCore/BuildTools/FormatValidation/validate_format_linux.sh"
+    fi
+  fi
+  
+  if [ "$SKIP" -eq 0 ]; then
+    python clang-format-validate.py --clang-format-executable "$BIN" \
+    -r ../../Common ../../Graphics ../../Platforms ../../Primitives ../../Tests \
+    --exclude ../../Graphics/HLSL2GLSLConverterLib/include/GLSLDefinitions.h \
+    --exclude ../../Graphics/HLSL2GLSLConverterLib/include/GLSLDefinitions_inc.h \
+    --exclude ../../Graphics/GraphicsEngineVulkan/shaders/GenerateMipsCS_inc.h \
+    --exclude ../../Tests/DiligentCoreAPITest/assets/*
+  fi
+fi

--- a/BuildTools/FormatValidation/validate_format_linux.sh
+++ b/BuildTools/FormatValidation/validate_format_linux.sh
@@ -23,7 +23,7 @@ if [ $? -ne 0 ]; then
   fi
 fi
 
-if [ ! -z $BIN ]; then
+if [ ! -z "$BIN" ]; then
   python clang-format-validate.py --clang-format-executable "$BIN" \
   -r ../../Common ../../Graphics ../../Platforms ../../Primitives ../../Tests \
   --exclude ../../Graphics/HLSL2GLSLConverterLib/include/GLSLDefinitions.h \

--- a/BuildTools/FormatValidation/validate_format_linux.sh
+++ b/BuildTools/FormatValidation/validate_format_linux.sh
@@ -1,35 +1,33 @@
 #!/bin/bash
 
-## Set the shipped BIN
-BIN="./clang-format_linux_10.0.0"
-## ...or use the find command to avoid maintaining
-#BIN=$(find . -name 'clang-format_linux*')
+BIN=$(find . -name 'clang-format_linux_*')
 
-## Set to anything but 0 to force skip format validation
-SKIP=0
-
-if [ "$SKIP" -eq 0 ]; then
-  ## Try to get the version
-  eval "$BIN" --version > /dev/null 2>&1
+## Try to launch the bin
+eval "$BIN --version >/dev/null 2> /dev/null"
+if [ $? -ne 0 ]; then
+  ## BIN failed to run, try to get a system installed clang-format
+  SYS_BIN=$(which clang-format 2> /dev/null)
   if [ $? -ne 0 ]; then
-    ## Try to get a system installed clang-format
-    BIN=$(which clang-format 2> /dev/null)
-    if [ $? -ne 0 ]; then
-      echo "WARNING: skipping format validation as no suitable executable was found"
-      SKIP=1
-    else
-      echo "WARNING: could not load the integrated format validator binary, but a system one was found."
-      echo "   Should it cause any issue due to versioning, you can skip validation by setting \"SKIP=1\""
-      echo "   in: DiligentCore/BuildTools/FormatValidation/validate_format_linux.sh"
+    echo "WARNING: skipping format validation as no suitable executable was found"
+    BIN=""
+  else
+    BIN_VERSION=$(echo $BIN | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+')
+    SYS_BIN_VERSION=$(eval "$SYS_BIN --version" | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+')
+    if [ "$BIN_VERSION" != "$SYS_BIN_VERSION" ]; then
+      echo "WARNING: could not load the provided clang-format for validation."
+      echo "   clang-format exists in the system path however its version is $SYS_BIN_VERSION instead of $BIN_VERSION"
+      echo "   Should the validation fail, you can try skipping it by setting the cmake option:"
+      echo "   DILIGENT_SKIP_FORMAT_VALIDATION"
     fi
+    BIN="$SYS_BIN"
   fi
-  
-  if [ "$SKIP" -eq 0 ]; then
-    python clang-format-validate.py --clang-format-executable "$BIN" \
-    -r ../../Common ../../Graphics ../../Platforms ../../Primitives ../../Tests \
-    --exclude ../../Graphics/HLSL2GLSLConverterLib/include/GLSLDefinitions.h \
-    --exclude ../../Graphics/HLSL2GLSLConverterLib/include/GLSLDefinitions_inc.h \
-    --exclude ../../Graphics/GraphicsEngineVulkan/shaders/GenerateMipsCS_inc.h \
-    --exclude ../../Tests/DiligentCoreAPITest/assets/*
-  fi
+fi
+
+if [ ! -z $BIN ]; then
+  python clang-format-validate.py --clang-format-executable "$BIN" \
+  -r ../../Common ../../Graphics ../../Platforms ../../Primitives ../../Tests \
+  --exclude ../../Graphics/HLSL2GLSLConverterLib/include/GLSLDefinitions.h \
+  --exclude ../../Graphics/HLSL2GLSLConverterLib/include/GLSLDefinitions_inc.h \
+  --exclude ../../Graphics/GraphicsEngineVulkan/shaders/GenerateMipsCS_inc.h \
+  --exclude ../../Tests/DiligentCoreAPITest/assets/*
 fi

--- a/BuildTools/FormatValidation/validate_format_linux.sh
+++ b/BuildTools/FormatValidation/validate_format_linux.sh
@@ -10,7 +10,7 @@ SKIP=0
 
 if [ "$SKIP" -eq 0 ]; then
   ## Try to get the version
-  eval "$BIN" --version 2> /dev/null  
+  eval "$BIN" --version > /dev/null 2>&1
   if [ $? -ne 0 ]; then
     ## Try to get a system installed clang-format
     BIN=$(which clang-format 2> /dev/null)


### PR DESCRIPTION
Fix for https://github.com/DiligentGraphics/DiligentEngine/issues/79