### PR TITLE
Fixed CMake generation error when CMAKE_VS_WINDOWS_TARGET_PALTFORM_VE…

### DIFF
--- a/Graphics/GraphicsEngineD3D12/CMakeLists.txt
+++ b/Graphics/GraphicsEngineD3D12/CMakeLists.txt
@@ -179,7 +179,7 @@ PUBLIC
 )
 target_compile_definitions(Diligent-GraphicsEngineD3D12-shared PUBLIC ENGINE_DLL=1)
 
-if(${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION} STRGREATER_EQUAL "10.0.19041.0")
+if("${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION}" STRGREATER_EQUAL "10.0.19041.0")
     set(D3D12_H_HAS_MESH_SHADER ON CACHE INTERNAL "D3D12 headers support mesh shaders" FORCE)
     target_compile_definitions(Diligent-GraphicsEngineD3D12-static PRIVATE D3D12_H_HAS_MESH_SHADER=1)
 endif()


### PR DESCRIPTION
For whatever reason, ${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION} evaluates to empty when I run cmake on Windows. It's not because I don't have a Windows SDK installed and it's not because I'm using an old version of cmake - I'm using 3.18.3.

When the above variable is empty, the command modified in the patch expanded to...

if(STRGREATER_EQUAL "10.0.19041.0")

...which is a syntax error. With this change, it now expands to...

if("" STRGREATER_EQUAL "10.0.19041.0")

...which is valid and results in mesh shader support being disabled, which seems like the right thing to do if no Windows SDK is available.

This is the error log I got from cmake before this change.

1> [CMake] CMake Error at Graphics/GraphicsEngineD3D12/CMakeLists.txt:182 (if):
1> [CMake]   if given arguments:
1> [CMake] 
1> [CMake]     "STRGREATER_EQUAL" "10.0.19041.0"
1> [CMake] 
1> [CMake]   Unknown arguments specified
