### PR TITLE
Update error message for mismatched clang-format

### DIFF
--- a/BuildTools/FormatValidation/validate_format_linux_implementation.sh
+++ b/BuildTools/FormatValidation/validate_format_linux_implementation.sh
@@ -24,7 +24,7 @@ function find_validator_bin() {
         errcho "WARNING: could not load the provided clang-format for validation."
         errcho "   clang-format exists in the system path however its version is $SYS_BIN_VERSION instead of $BIN_VERSION"
         errcho "   Should the validation fail, you can try skipping it by setting the cmake option:"
-        errcho "   DILIGENT_SKIP_FORMAT_VALIDATION"
+        errcho "   DILIGENT_NO_FORMAT_VALIDATION"
       fi
       BIN="$SYS_BIN"
     fi


### PR DESCRIPTION
The error message when a user has a newer version of clang-format prompts users to try a CMake variable that no-longer exists.

