### PR TITLE
Fixed uninitialized atomic in StateObjectsRegistry

### DIFF
--- a/Graphics/GraphicsEngine/include/StateObjectsRegistry.hpp
+++ b/Graphics/GraphicsEngine/include/StateObjectsRegistry.hpp
@@ -66,6 +66,7 @@ public:
     static constexpr int DeletedObjectsToPurge = 32;
 
     StateObjectsRegistry(IMemoryAllocator& RawAllocator, const Char* RegistryName) :
+        m_NumDeletedObjects{0},
         m_DescToObjHashMap(STD_ALLOCATOR_RAW_MEM(HashMapElem, RawAllocator, "Allocator for unordered_map<ResourceDescType, RefCntWeakPtr<IDeviceObject> >")),
         m_RegistryName{RegistryName}
     {}


### PR DESCRIPTION
Add() method was attempting to read m_NumDeletedObjects before it was initialized.