### PR TITLE
fix: warning C5054 in VS2019

### DIFF
--- a/Common/CMakeLists.txt
+++ b/Common/CMakeLists.txt
@@ -34,6 +34,7 @@ set(INTERFACE
     interface/UniqueIdentifier.hpp
     interface/ValidatedCast.hpp
     interface/CompilerDefinitions.h
+    interface/EnumCast.hpp
 )
 
 set(SOURCE 

--- a/Common/interface/EnumCast.hpp
+++ b/Common/interface/EnumCast.hpp
@@ -1,0 +1,41 @@
+﻿/*
+ *  Copyright 2019-2021 Diligent Graphics LLC
+ *  
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  In no event and under no legal theory, whether in tort (including negligence), 
+ *  contract, or otherwise, unless required by applicable law (such as deliberate 
+ *  and grossly negligent acts) or agreed to in writing, shall any Contributor be
+ *  liable for any damages, including any direct, indirect, special, incidental, 
+ *  or consequential damages of any character arising as a result of this License or 
+ *  out of the use or inability to use the software (including but not limited to damages 
+ *  for loss of goodwill, work stoppage, computer failure or malfunction, or any and 
+ *  all other commercial damages or losses), even if such Contributor has been advised 
+ *  of the possibility of such damages.
+ */
+
+#pragma once
+
+#include <type_traits>
+
+namespace Diligent
+{
+
+template <typename T>
+constexpr typename std::underlying_type<T>::type EnumCast(T x)
+{
+    static_assert(std::is_enum<T>::value, "Must be an enum!");
+    return static_cast<typename std::underlying_type<T>::type>(x);
+}
+
+} // namespace Diligent

--- a/Graphics/GraphicsEngineVulkan/src/PipelineResourceSignatureVkImpl.cpp
+++ b/Graphics/GraphicsEngineVulkan/src/PipelineResourceSignatureVkImpl.cpp
@@ -36,6 +36,7 @@
 #include "VulkanTypeConversions.hpp"
 #include "DynamicLinearAllocator.hpp"
 #include "SPIRVShaderResources.hpp"
+#include "EnumCast.hpp"
 
 namespace Diligent
 {
@@ -116,7 +117,7 @@ inline PipelineResourceSignatureVkImpl::CACHE_GROUP PipelineResourceSignatureVkI
 {
     // NB: SetId is always 0 for static/mutable variables, and 1 - for dynamic ones.
     //     It is not the actual descriptor set index in the set layout!
-    const auto SetId             = VarTypeToDescriptorSetId(Res.VarType);
+    const auto SetId             = EnumCast(VarTypeToDescriptorSetId(Res.VarType));
     const bool WithDynamicOffset = (Res.Flags & PIPELINE_RESOURCE_FLAG_NO_DYNAMIC_BUFFERS) == 0;
     const bool UseTexelBuffer    = (Res.Flags & PIPELINE_RESOURCE_FLAG_FORMATTED_BUFFER) != 0;
 


### PR DESCRIPTION
Arithmetic between different enum types is deprecated, so a cast is
necessary.

Just because it's not immediately obvious from the code change, the issue occurs in `Graphics/GraphicsEngineVulkan/src/PipelineResourceSignatureVkImpl.cpp` when multiplying `SetId` (`PipelineResourceSignatureVkImpl::DESCRIPTOR_SET_ID`) with the `CACHE_GROUP` enum.