### PR TITLE
✨: Implemented A8_UNORM texture support for OpenGL and Vulkan backends

### DIFF
--- a/Graphics/GraphicsEngineOpenGL/src/GLTypeConversions.cpp
+++ b/Graphics/GraphicsEngineOpenGL/src/GLTypeConversions.cpp
@@ -123,7 +123,9 @@ public:
         m_FmtToGLFmtMap[TEX_FORMAT_R8_UINT]                = GL_R8UI;
         m_FmtToGLFmtMap[TEX_FORMAT_R8_SNORM]               = GL_R8_SNORM;
         m_FmtToGLFmtMap[TEX_FORMAT_R8_SINT]                = GL_R8I;
-        m_FmtToGLFmtMap[TEX_FORMAT_A8_UNORM]               = 0;
+        // To get the same behaviour as expected for TEX_FORMAT_A8_UNORM we swizzle the components
+        // appropriately using the GL_TEXTURE_SWIZZLE texture parameters in TextureBaseGL::SetDefaultGLParameters()
+        m_FmtToGLFmtMap[TEX_FORMAT_A8_UNORM]               = GL_R8;
 
         m_FmtToGLFmtMap[TEX_FORMAT_R1_UNORM]               = 0;
 
@@ -352,7 +354,9 @@ NativePixelAttribs GetNativePixelTransferAttribs(TEXTURE_FORMAT TexFormat)
         FmtToGLPixelFmt[TEX_FORMAT_R8_UINT]                = NativePixelAttribs(GL_RED_INTEGER,  GL_UNSIGNED_BYTE);
         FmtToGLPixelFmt[TEX_FORMAT_R8_SNORM]               = NativePixelAttribs(GL_RED,          GL_BYTE);
         FmtToGLPixelFmt[TEX_FORMAT_R8_SINT]                = NativePixelAttribs(GL_RED_INTEGER,  GL_BYTE);
-        FmtToGLPixelFmt[TEX_FORMAT_A8_UNORM]               = NativePixelAttribs();
+        // To get the same behaviour as expected for TEX_FORMAT_A8_UNORM we swizzle the components
+        // appropriately using the GL_TEXTURE_SWIZZLE texture parameters in TextureBaseGL::SetDefaultGLParameters()
+        FmtToGLPixelFmt[TEX_FORMAT_A8_UNORM]               = NativePixelAttribs(GL_RED,          GL_UNSIGNED_BYTE);
 
         FmtToGLPixelFmt[TEX_FORMAT_R1_UNORM]               = NativePixelAttribs();
 

--- a/Graphics/GraphicsEngineOpenGL/src/RenderDeviceGLImpl.cpp
+++ b/Graphics/GraphicsEngineOpenGL/src/RenderDeviceGLImpl.cpp
@@ -926,13 +926,16 @@ void RenderDeviceGLImpl::InitAdapterInfo()
 
 void RenderDeviceGLImpl::FlagSupportedTexFormats()
 {
-    const auto& DeviceInfo   = GetDeviceInfo();
-    const auto  bGL33OrAbove = DeviceInfo.Type == RENDER_DEVICE_TYPE_GL && DeviceInfo.APIVersion >= Version{3, 3};
+    const auto& DeviceInfo     = GetDeviceInfo();
+    const auto  bGL33OrAbove   = DeviceInfo.Type == RENDER_DEVICE_TYPE_GL && DeviceInfo.APIVersion >= Version{3, 3};
+    const auto  bGLES30OrAbove = DeviceInfo.Type == RENDER_DEVICE_TYPE_GLES && DeviceInfo.APIVersion >= Version{3, 0};
 
-    const bool bRGTC      = CheckExtension("GL_ARB_texture_compression_rgtc");
-    const bool bBPTC      = CheckExtension("GL_ARB_texture_compression_bptc");
-    const bool bS3TC      = CheckExtension("GL_EXT_texture_compression_s3tc");
-    const bool bTexNorm16 = CheckExtension("GL_EXT_texture_norm16"); // Only for ES3.1+
+    const bool bRGTC       = CheckExtension("GL_ARB_texture_compression_rgtc");
+    const bool bBPTC       = CheckExtension("GL_ARB_texture_compression_bptc");
+    const bool bS3TC       = CheckExtension("GL_EXT_texture_compression_s3tc");
+    const bool bTexNorm16  = CheckExtension("GL_EXT_texture_norm16"); // Only for ES3.1+
+    const bool bTexSwizzle = bGL33OrAbove || bGLES30OrAbove || CheckExtension("GL_ARB_texture_swizzle");
+
 
 #define FLAG_FORMAT(Fmt, IsSupported) \
     m_TextureFormatsInfo[Fmt].Supported = IsSupported
@@ -1005,7 +1008,7 @@ void RenderDeviceGLImpl::FlagSupportedTexFormats()
     FLAG_FORMAT(TEX_FORMAT_R8_UINT,                    true);
     FLAG_FORMAT(TEX_FORMAT_R8_SNORM,                   true);
     FLAG_FORMAT(TEX_FORMAT_R8_SINT,                    true);
-    FLAG_FORMAT(TEX_FORMAT_A8_UNORM,                   false); // Not supported in OpenGL
+    FLAG_FORMAT(TEX_FORMAT_A8_UNORM,                   bTexSwizzle);
     FLAG_FORMAT(TEX_FORMAT_R1_UNORM,                   false); // Not supported in OpenGL
     FLAG_FORMAT(TEX_FORMAT_RGB9E5_SHAREDEXP,           true);
     FLAG_FORMAT(TEX_FORMAT_RG8_B8G8_UNORM,             false); // Not supported in OpenGL

--- a/Graphics/GraphicsEngineOpenGL/src/TextureBaseGL.cpp
+++ b/Graphics/GraphicsEngineOpenGL/src/TextureBaseGL.cpp
@@ -674,6 +674,16 @@ void TextureBaseGL::SetDefaultGLParameters()
     }
 #endif
 
+    if (m_Desc.Format == TEX_FORMAT_A8_UNORM)
+    {
+        // We need to do channel swizzling since TEX_FORMAT_A8_UNORM
+        // is actually implemented using GL_RED
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_R, GL_ZERO);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_G, GL_ZERO);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_B, GL_ZERO);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_A, GL_RED);
+    }
+
     if (m_BindTarget != GL_TEXTURE_2D_MULTISAMPLE &&
         m_BindTarget != GL_TEXTURE_2D_MULTISAMPLE_ARRAY)
     {

--- a/Graphics/GraphicsEngineVulkan/src/TextureVkImpl.cpp
+++ b/Graphics/GraphicsEngineVulkan/src/TextureVkImpl.cpp
@@ -630,16 +630,30 @@ VulkanUtilities::ImageViewWrapper TextureVkImpl::CreateImageView(TextureViewDesc
         default: UNEXPECTED("Unexpected view dimension");
     }
 
-    TEXTURE_FORMAT CorrectedViewFormat = ViewDesc.Format;
+    TEXTURE_FORMAT OriginalFormat      = ViewDesc.Format;
+    TEXTURE_FORMAT CorrectedViewFormat = OriginalFormat;
     if (m_Desc.BindFlags & BIND_DEPTH_STENCIL)
         CorrectedViewFormat = GetDefaultTextureViewFormat(CorrectedViewFormat, TEXTURE_VIEW_DEPTH_STENCIL, m_Desc.BindFlags);
-    ImageViewCI.format     = TexFormatToVkFormat(CorrectedViewFormat);
-    ImageViewCI.components = {
-        VK_COMPONENT_SWIZZLE_IDENTITY,
-        VK_COMPONENT_SWIZZLE_IDENTITY,
-        VK_COMPONENT_SWIZZLE_IDENTITY,
-        VK_COMPONENT_SWIZZLE_IDENTITY //
-    };
+    ImageViewCI.format = TexFormatToVkFormat(CorrectedViewFormat);
+    if (OriginalFormat != TEX_FORMAT_A8_UNORM)
+    {
+        ImageViewCI.components = {
+            VK_COMPONENT_SWIZZLE_IDENTITY,
+            VK_COMPONENT_SWIZZLE_IDENTITY,
+            VK_COMPONENT_SWIZZLE_IDENTITY,
+            VK_COMPONENT_SWIZZLE_IDENTITY //
+        };
+    }
+    else
+    {
+        ImageViewCI.components = {
+            VK_COMPONENT_SWIZZLE_ZERO,
+            VK_COMPONENT_SWIZZLE_ZERO,
+            VK_COMPONENT_SWIZZLE_ZERO,
+            VK_COMPONENT_SWIZZLE_R //
+        };
+    }
+
     ImageViewCI.subresourceRange.baseMipLevel = ViewDesc.MostDetailedMip;
     ImageViewCI.subresourceRange.levelCount   = ViewDesc.NumMipLevels;
     if (ViewDesc.TextureDim == RESOURCE_DIM_TEX_1D_ARRAY ||

--- a/Graphics/GraphicsEngineVulkan/src/VulkanTypeConversions.cpp
+++ b/Graphics/GraphicsEngineVulkan/src/VulkanTypeConversions.cpp
@@ -123,7 +123,9 @@ public:
         m_FmtToVkFmtMap[TEX_FORMAT_R8_UINT]     = VK_FORMAT_R8_UINT;
         m_FmtToVkFmtMap[TEX_FORMAT_R8_SNORM]    = VK_FORMAT_R8_SNORM;
         m_FmtToVkFmtMap[TEX_FORMAT_R8_SINT]     = VK_FORMAT_R8_SINT;
-        m_FmtToVkFmtMap[TEX_FORMAT_A8_UNORM]    = VK_FORMAT_UNDEFINED;
+        // To get the same behaviour as expected for TEX_FORMAT_A8_UNORM we
+        // swizzle the components appropriately using the VkImageViewCreateInfo struct
+        m_FmtToVkFmtMap[TEX_FORMAT_A8_UNORM]    = VK_FORMAT_R8_UNORM;
 
         m_FmtToVkFmtMap[TEX_FORMAT_R1_UNORM]    = VK_FORMAT_UNDEFINED;
 


### PR DESCRIPTION
The support is achieved by using the OpenGL/Vulkan swizzling functionality

Change-type: minor
Signed-off-by: Thomas Valta <thomas.valta@reactivereality.com>