### PR TITLE
Fix ubuntu build errors

### DIFF
--- a/Common/interface/UniqueIdentifier.hpp
+++ b/Common/interface/UniqueIdentifier.hpp
@@ -66,7 +66,7 @@ public:
     {
         if (m_ID == 0)
         {
-            static std::atomic_int32_t GlobalCounter{0};
+            static std::atomic<std::int32_t> GlobalCounter{0};
             m_ID = GlobalCounter.fetch_add(1) + 1;
         }
         return m_ID;

--- a/Graphics/GraphicsEngine/include/EngineFactoryBase.hpp
+++ b/Graphics/GraphicsEngine/include/EngineFactoryBase.hpp
@@ -60,6 +60,8 @@ public:
     {
     }
 
+    virtual ~EngineFactoryBase() = default;
+
     virtual void DILIGENT_CALL_TYPE QueryInterface(const INTERFACE_ID& IID, IObject** ppInterface) override final
     {
         if (ppInterface == nullptr)

--- a/Graphics/GraphicsEngine/include/FenceBase.hpp
+++ b/Graphics/GraphicsEngine/include/FenceBase.hpp
@@ -111,10 +111,10 @@ protected:
         }
     }
 
-    std::atomic_uint64_t m_LastCompletedFenceValue{0};
+    std::atomic<uint64_t> m_LastCompletedFenceValue{0};
 
 #ifdef DILIGENT_DEVELOPMENT
-    std::atomic_uint64_t m_EnqueuedFenceValue{0};
+    std::atomic<uint64_t> m_EnqueuedFenceValue{0};
 #endif
 };
 

--- a/Graphics/GraphicsEngine/src/DeviceContextBase.cpp
+++ b/Graphics/GraphicsEngine/src/DeviceContextBase.cpp
@@ -675,10 +675,12 @@ bool VerifyBuildTLASAttribs(const BuildTLASAttribs& Attribs, const RayTracingPro
     // Calculate instance data size
     for (Uint32 i = 0; i < Attribs.InstanceCount; ++i)
     {
-        constexpr Uint32 BitMask = (1u << 24) - 1;
-        const auto&      Inst    = Attribs.pInstances[i];
+        const auto& Inst = Attribs.pInstances[i];
 
+#ifdef DILIGENT_DEBUG
+        constexpr Uint32 BitMask = (1u << 24) - 1);
         VERIFY((Inst.CustomId & ~BitMask) == 0, "Only the lower 24 bits are used.");
+#endif
 
         VERIFY(Inst.ContributionToHitGroupIndex == TLAS_INSTANCE_OFFSET_AUTO ||
                    (Inst.ContributionToHitGroupIndex & ~BitMask) == 0,

--- a/Graphics/GraphicsEngine/src/PipelineStateBase.cpp
+++ b/Graphics/GraphicsEngine/src/PipelineStateBase.cpp
@@ -584,18 +584,21 @@ void CopyRTShaderGroupNames(std::unordered_map<HashMapStringKey, Uint32, HashMap
     {
         const auto* Name      = CreateInfo.pGeneralShaders[i].Name;
         const bool  IsNewName = NameToGroupIndex.emplace(HashMapStringKey{MemPool.CopyString(Name)}, GroupIndex++).second;
+        (void)IsNewName;
         VERIFY(IsNewName, "All group names must be unique. ValidateRayTracingPipelineCreateInfo() should've caught this error.");
     }
     for (Uint32 i = 0; i < CreateInfo.TriangleHitShaderCount; ++i)
     {
         const auto* Name      = CreateInfo.pTriangleHitShaders[i].Name;
         const bool  IsNewName = NameToGroupIndex.emplace(HashMapStringKey{MemPool.CopyString(Name)}, GroupIndex++).second;
+        (void)IsNewName;
         VERIFY(IsNewName, "All group names must be unique. ValidateRayTracingPipelineCreateInfo() should've caught this error.");
     }
     for (Uint32 i = 0; i < CreateInfo.ProceduralHitShaderCount; ++i)
     {
         const auto* Name      = CreateInfo.pProceduralHitShaders[i].Name;
         const bool  IsNewName = NameToGroupIndex.emplace(HashMapStringKey{MemPool.CopyString(Name)}, GroupIndex++).second;
+        (void)IsNewName;
         VERIFY(IsNewName, "All group names must be unique. ValidateRayTracingPipelineCreateInfo() should've caught this error.");
     }
 

--- a/Graphics/GraphicsEngine/src/TextureBase.cpp
+++ b/Graphics/GraphicsEngine/src/TextureBase.cpp
@@ -100,6 +100,7 @@ void ValidateTextureDesc(const TextureDesc& Desc, const IRenderDevice* pDevice) 
             LOG_TEXTURE_ERROR_AND_THROW("Texture cube/cube array must have at least 6 slices (", Desc.ArraySize, " provided).");
     }
 
+#ifdef DILIGENT_DEBUG
     Uint32 MaxDim = 0;
     if (Desc.Type == RESOURCE_DIM_TEX_1D || Desc.Type == RESOURCE_DIM_TEX_1D_ARRAY)
         MaxDim = Desc.Width;
@@ -108,6 +109,7 @@ void ValidateTextureDesc(const TextureDesc& Desc, const IRenderDevice* pDevice) 
     else if (Desc.Type == RESOURCE_DIM_TEX_3D)
         MaxDim = std::max(std::max(Desc.Width, Desc.Height), Desc.Depth);
     VERIFY(MaxDim >= (1U << (Desc.MipLevels - 1)), "Texture '", Desc.Name ? Desc.Name : "", "': Incorrect number of Mip levels (", Desc.MipLevels, ").");
+#endif
 
     if (Desc.SampleCount > 1)
     {

--- a/Graphics/GraphicsEngineOpenGL/src/ShaderVariableManagerGL.cpp
+++ b/Graphics/GraphicsEngineOpenGL/src/ShaderVariableManagerGL.cpp
@@ -187,8 +187,11 @@ void ShaderVariableManagerGL::Destroy(IMemoryAllocator& Allocator)
 
 void ShaderVariableManagerGL::UniformBuffBindInfo::BindResource(const BindResourceInfo& BindInfo)
 {
+#if (DILIGENT_DEVELOPMENT || DILIGENT_DEBUG)
     const auto& Desc = GetDesc();
+#endif
     const auto& Attr = GetAttribs();
+
 
     VERIFY(BindInfo.ArrayIndex < Desc.ArraySize, "Index is out of range, but it should've been corrected by ShaderVariableBase::SetArray()");
     VERIFY_EXPR(Desc.ResourceType == SHADER_RESOURCE_TYPE_CONSTANT_BUFFER);
@@ -212,7 +215,9 @@ void ShaderVariableManagerGL::UniformBuffBindInfo::BindResource(const BindResour
 void ShaderVariableManagerGL::UniformBuffBindInfo::SetDynamicOffset(Uint32 ArrayIndex, Uint32 Offset)
 {
     const auto& Attr = GetAttribs();
+#if (DILIGENT_DEVELOPMENT || DILIGENT_DEBUG)
     const auto& Desc = GetDesc();
+#endif
     VERIFY_EXPR(Desc.ResourceType == SHADER_RESOURCE_TYPE_CONSTANT_BUFFER);
 #ifdef DILIGENT_DEVELOPMENT
     {
@@ -344,7 +349,9 @@ void ShaderVariableManagerGL::ImageBindInfo::BindResource(const BindResourceInfo
 
 void ShaderVariableManagerGL::StorageBufferBindInfo::BindResource(const BindResourceInfo& BindInfo)
 {
+#if (DILIGENT_DEVELOPMENT || DILIGENT_DEBUG)
     const auto& Desc = GetDesc();
+#endif
     const auto& Attr = GetAttribs();
 
     VERIFY(BindInfo.ArrayIndex < Desc.ArraySize, "Index is out of range, but it should've been corrected by ShaderVariableBase::SetArray()");
@@ -376,7 +383,9 @@ void ShaderVariableManagerGL::StorageBufferBindInfo::BindResource(const BindReso
 void ShaderVariableManagerGL::StorageBufferBindInfo::SetDynamicOffset(Uint32 ArrayIndex, Uint32 Offset)
 {
     const auto& Attr = GetAttribs();
+#if (DILIGENT_DEVELOPMENT || DILIGENT_DEBUG)
     const auto& Desc = GetDesc();
+#endif
     VERIFY_EXPR(Desc.ResourceType == SHADER_RESOURCE_TYPE_BUFFER_SRV ||
                 Desc.ResourceType == SHADER_RESOURCE_TYPE_BUFFER_UAV);
 #ifdef DILIGENT_DEVELOPMENT

--- a/Graphics/GraphicsEngineOpenGL/src/VAOCache.cpp
+++ b/Graphics/GraphicsEngineOpenGL/src/VAOCache.cpp
@@ -177,7 +177,9 @@ VAOCache::VAOHashKey::VAOHashKey(const VAOAttribs& Attribs) :
         }
         else
         {
+#ifdef DILIGENT_DEBUG
             const auto& DstStream = Streams[BufferSlot];
+#endif
             // The slot has already been initialized
             VERIFY_EXPR(DstStream.BufferUId == BuffId);
             VERIFY_EXPR(DstStream.Offset == SrcStream.Offset);

--- a/Graphics/GraphicsTools/src/DynamicTextureAtlas.cpp
+++ b/Graphics/GraphicsTools/src/DynamicTextureAtlas.cpp
@@ -343,8 +343,7 @@ private:
 
     FixedBlockMemoryAllocator m_SuballocationsAllocator;
 
-    std::atomic_uint32_t m_Version = {};
-
+    std::atomic<uint32_t> m_Version = {};
 
     struct SliceManager
     {

--- a/Graphics/HLSL2GLSLConverterLib/src/HLSL2GLSLConverterImpl.cpp
+++ b/Graphics/HLSL2GLSLConverterLib/src/HLSL2GLSLConverterImpl.cpp
@@ -1771,7 +1771,7 @@ void HLSL2GLSLConverterImpl::ConversionStream::ParseSamplers(TokenListType::iter
         else
             ++Token;
     }
-    VERIFY_PARSER_STATE(Token, ScopeDepth == 1 && Token == m_Tokens.end() || ScopeDepth == 0, "Error parsing scope");
+    VERIFY_PARSER_STATE(Token, (ScopeDepth == 1 && Token == m_Tokens.end()) || ScopeDepth == 0, "Error parsing scope");
 }
 
 void ParseImageFormat(const String& Comment, String& ImageFormat)
@@ -3065,7 +3065,7 @@ void HLSL2GLSLConverterImpl::ConversionStream::ProcessFunctionParameters(TokenLi
                     // ^
                     ParamInfo.GSAttribs.PrimType = ShaderParameterInfo::GSAttributes::PrimitiveType::TriangleAdj;
                     ++Token;
-
+                // fall through
                 case TokenType::kw_TriangleStream:
                 case TokenType::kw_PointStream:
                 case TokenType::kw_LineStream:
@@ -3975,6 +3975,7 @@ void HLSL2GLSLConverterImpl::ConversionStream::ProcessHullShaderArguments(TokenL
         quad,
         isoline
     } domain = Domain::undefined;
+    (void)domain;
     enum class Partitioning
     {
         undefined,
@@ -3983,6 +3984,7 @@ void HLSL2GLSLConverterImpl::ConversionStream::ProcessHullShaderArguments(TokenL
         fractional_odd,
         pow2
     } partitioning = Partitioning::undefined;
+    (void)partitioning;
     enum class OutputTopology
     {
         undefined,
@@ -3991,6 +3993,7 @@ void HLSL2GLSLConverterImpl::ConversionStream::ProcessHullShaderArguments(TokenL
         triangle_cw,
         triangle_ccw
     } topology = OutputTopology::undefined;
+    (void)topology;
 
     std::unordered_map<HashMapStringKey, String, HashMapStringKey::Hasher> Attributes;
     ProcessShaderAttributes(Token, Attributes);


### PR DESCRIPTION
This fixes a variety of build errors on Ubuntu (clang and gcc), although some would occur on other platforms.

The `std::atomic_int32_t` and `std::atomic_unt64_t` type aliases are optional and were not available for me, so I replaced with `std::atomic<std::int32_t>` and `std::atomic<std::uint64_t>` which are always portable.

I also fixed several unused variable warnings because of code that was only used in debug mode, and
Added a magic `// fall through` comment that is the most portable way to tell compilers to be okay with
a switch case fallthough.

I also added a default virtual destructor to `EngineFactoryBase` (`virtual ~EngineFactoryBase() = default;`) which, it should have anyway, to prevent a warning with my system and compiler mix.

I've tried to keep the impact of these changes as low as possible. I should also mention that I have only been able to compile the `OpenGL` backend so far, (I've had to make my own bazel `BUILD` file, so it has been some effort).
Let me know if you think these changes don't belong upstream, I can always just maintain an internal fork if needed.

Also, at HLSL2GLSLConverterImpl.cpp:1774 I fixed a `-WParentheses` warning, but I'm not sure I interpreted your intent correctly.