### PR TITLE
Fix typos

### DIFF
--- a/Graphics/GraphicsAccessories/interface/GraphicsAccessories.hpp
+++ b/Graphics/GraphicsAccessories/interface/GraphicsAccessories.hpp
@@ -531,9 +531,9 @@ PIPELINE_TYPE PipelineTypeFromShaderStages(SHADER_TYPE ShaderStages);
 ///                           to whole subresources only, but not to the row/depth strides.
 ///                           In other words, there may be padding between subresources, but
 ///                           texels in every subresource are assumed to be tightly packed.
-/// \param [in] LocationX   - X location within the subresoure.
-/// \param [in] LocationY   - Y location within the subresoure.
-/// \param [in] LocationZ   - Z location within the subresoure.
+/// \param [in] LocationX   - X location within the subresource.
+/// \param [in] LocationY   - Y location within the subresource.
+/// \param [in] LocationZ   - Z location within the subresource.
 ///
 /// \return     Offset from the beginning of the buffer to the given location.
 ///

--- a/Graphics/GraphicsEngine/include/IndexWrapper.hpp
+++ b/Graphics/GraphicsEngine/include/IndexWrapper.hpp
@@ -41,7 +41,7 @@ public:
     explicit IndexWrapper(T Value) noexcept :
         m_Value{static_cast<IndexType>(Value)}
     {
-        VERIFY(static_cast<T>(m_Value) == Value, "Not enought bits to store value ", Value);
+        VERIFY(static_cast<T>(m_Value) == Value, "Not enough bits to store value ", Value);
     }
 
     template <typename OtherType, typename OtherTag>
@@ -66,7 +66,7 @@ public:
     IndexWrapper& operator=(const T& Value)
     {
         m_Value = static_cast<IndexType>(Value);
-        VERIFY(static_cast<T>(m_Value) == Value, "Not enought bits to store value ", Value);
+        VERIFY(static_cast<T>(m_Value) == Value, "Not enough bits to store value ", Value);
         return *this;
     }
 

--- a/Graphics/GraphicsEngine/include/RenderDeviceBase.hpp
+++ b/Graphics/GraphicsEngine/include/RenderDeviceBase.hpp
@@ -234,7 +234,7 @@ public:
     /// \param RawMemAllocator - Allocator that will be used to allocate memory for all device objects (including render device itself)
     /// \param pEngineFactory  - Engine factory that was used to create this device
     /// \param EngineCI        - Engigne create info struct, see Diligent::EngineCreateInfo.
-    /// \param AdapterInfo     - Graphics adatper info, see Diligent::AdapterInfo.
+    /// \param AdapterInfo     - Graphics adapter info, see Diligent::AdapterInfo.
     ///
     /// \remarks Render device uses fixed block allocators (see FixedBlockMemoryAllocator) to allocate memory for
     ///          device objects. The object sizes from EngineImplTraits are used to initialize the allocators.

--- a/Graphics/GraphicsEngine/interface/BottomLevelAS.h
+++ b/Graphics/GraphicsEngine/interface/BottomLevelAS.h
@@ -171,7 +171,7 @@ struct BottomLevelASDesc DILIGENT_DERIVE(DeviceObjectAttribs)
     /// through that immediate context.
     ///
     /// \remarks    Only specify these bits that will indicate those immediate contexts where the BLAS
-    ///             will actually be used. Do not set unncessary bits as this will result in extra overhead.
+    ///             will actually be used. Do not set unnecessary bits as this will result in extra overhead.
     Uint64                     ImmediateContextMask    DEFAULT_INITIALIZER(1);
 
 #if DILIGENT_CPP_INTERFACE

--- a/Graphics/GraphicsEngine/interface/Buffer.h
+++ b/Graphics/GraphicsEngine/interface/Buffer.h
@@ -111,7 +111,7 @@ struct BufferDesc DILIGENT_DERIVE(DeviceObjectAttribs)
     /// through that immediate context.
     ///
     /// \remarks    Only specify these bits that will indicate those immediate contexts where the buffer
-    ///             will actually be used. Do not set unncessary bits as this will result in extra overhead.
+    ///             will actually be used. Do not set unnecessary bits as this will result in extra overhead.
     Uint64 ImmediateContextMask     DEFAULT_INITIALIZER(1);
 
 

--- a/Graphics/GraphicsEngine/interface/Constants.h
+++ b/Graphics/GraphicsEngine/interface/Constants.h
@@ -47,7 +47,7 @@ DILIGENT_BEGIN_NAMESPACE(Diligent)
 /// The maximum number of resource signatures that one pipeline can use
 #define DILIGENT_MAX_RESOURCE_SIGNATURES 8
 
-/// The maximim number of queues in graphics adapter description.
+/// The maximum number of queues in graphics adapter description.
 #define DILIGENT_MAX_ADAPTER_QUEUES 16
 
 static const Uint32 MAX_BUFFER_SLOTS        = DILIGENT_MAX_BUFFER_SLOTS;

--- a/Graphics/GraphicsEngine/interface/DeviceContext.h
+++ b/Graphics/GraphicsEngine/interface/DeviceContext.h
@@ -82,7 +82,7 @@ struct DeviceContextDesc
     /// Indicates if this is a deferred context.
     Bool         IsDeferred      DEFAULT_INITIALIZER(False);
 
-    /// Device contex ID. This value corresponds to the index of the device context
+    /// Device context ID. This value corresponds to the index of the device context
     /// in ppContexts array when the engine was initialized.
     /// When starting recording commands with a deferred context, the context id
     /// of the immediate context where the command list will be executed should be
@@ -1517,7 +1517,7 @@ DILIGENT_TYPED_ENUM(STATE_TRANSITION_FLAGS, Uint8)
     /// responsible for making sure that all subresources are indeed in the designated state.
     /// If not used, internal resource state will be unchanged.
     ///
-    /// \note This flag cannnot be used when StateTransitionDesc.TransitionType is STATE_TRANSITION_TYPE_BEGIN.
+    /// \note This flag cannot be used when StateTransitionDesc.TransitionType is STATE_TRANSITION_TYPE_BEGIN.
     STATE_TRANSITION_FLAG_UPDATE_STATE    = 1u << 0,
 
     /// If set, the contents of the resource will be discarded, when possible.

--- a/Graphics/GraphicsEngine/interface/GraphicsTypes.h
+++ b/Graphics/GraphicsEngine/interface/GraphicsTypes.h
@@ -2270,7 +2270,7 @@ struct AdapterMemoryInfo
     /// The amount of unified memory that can be directly accessed by both CPU and GPU, in bytes.
 
     /// \note Unified memory is where USAGE_UNIFIED resources are typically allocated, but
-    ///       resourecs with other usages may be allocated as well if there is no corresponding
+    ///       resources with other usages may be allocated as well if there is no corresponding
     ///       memory type.
     Uint64  UnifiedMemory       DEFAULT_INITIALIZER(0);
 
@@ -2416,7 +2416,7 @@ struct EngineCreateInfo
     /// Minimum required graphics API version (feature level for Direct3D).
     Version                  GraphicsAPIVersion     DEFAULT_INITIALIZER({});
 
-    /// A pointer to the array of NumImmediateContexts structs decribing immediate
+    /// A pointer to the array of NumImmediateContexts structs describing immediate
     /// device contexts to create. See Diligent::ImmediateContextCreateInfo.
 
     /// Every immediate device contexts encompases a command queue of a specific type.
@@ -2424,7 +2424,7 @@ struct EngineCreateInfo
     ///
     /// If not specified, single graphics context will be created.
     ///
-    /// Recomended configuration:
+    /// Recommended configuration:
     ///   * Modern discrete GPU:      1 graphics, 1 compute, 1 transfer context.
     ///   * Integrated or mobile GPU: 1..2 graphics contexts.
     const ImmediateContextCreateInfo* pImmediateContextInfo DEFAULT_INITIALIZER(nullptr);
@@ -2456,7 +2456,7 @@ struct EngineCreateInfo
     ///             the engine will successfully be initialized, but the feature will be disabled.
     ///             The actual feature state can be queried from DeviceCaps structure.
     ///
-    ///             Applications can query available device features for each graphics adpater with
+    ///             Applications can query available device features for each graphics adapter with
     ///             IEngineFactory::EnumerateAdapters().
     DeviceFeatures Features;
 

--- a/Graphics/GraphicsEngine/interface/PipelineState.h
+++ b/Graphics/GraphicsEngine/interface/PipelineState.h
@@ -140,7 +140,7 @@ struct PipelineResourceLayoutDesc
     /// then both resources in the example above will be combined into a single one.
     /// If there is another "g_Texture" in geometry shader, it will be separate from combined
     /// vertex-pixel "g_Texture".
-    /// This memeber has no effect on variables defined in Variables array.
+    /// This member has no effect on variables defined in Variables array.
     SHADER_TYPE                         DefaultVariableMergeStages DEFAULT_INITIALIZER(SHADER_TYPE_UNKNOWN);
 
     /// Number of elements in Variables array
@@ -373,7 +373,7 @@ struct PipelineStateDesc DILIGENT_DERIVE(DeviceObjectAttribs)
     /// through that immediate context.
     ///
     /// \remarks    Only specify these bits that will indicate those immediate contexts where the PSO
-    ///             will actually be used. Do not set unncessary bits as this will result in extra overhead.
+    ///             will actually be used. Do not set unnecessary bits as this will result in extra overhead.
     Uint64 ImmediateContextMask     DEFAULT_INITIALIZER(1);
 
     /// Pipeline layout description

--- a/Graphics/GraphicsEngine/interface/Texture.h
+++ b/Graphics/GraphicsEngine/interface/Texture.h
@@ -103,7 +103,7 @@ struct TextureDesc DILIGENT_DERIVE(DeviceObjectAttribs)
     /// through that immediate context.
     ///
     /// \remarks    Only specify these bits that will indicate those immediate contexts where the texture
-    ///             will actually be used. Do not set unncessary bits as this will result in extra overhead.
+    ///             will actually be used. Do not set unnecessary bits as this will result in extra overhead.
     Uint64 ImmediateContextMask         DEFAULT_INITIALIZER(1);
 
 

--- a/Graphics/GraphicsEngine/interface/TopLevelAS.h
+++ b/Graphics/GraphicsEngine/interface/TopLevelAS.h
@@ -66,7 +66,7 @@ struct TopLevelASDesc DILIGENT_DERIVE(DeviceObjectAttribs)
     /// through that immediate context.
     ///
     /// \remarks    Only specify these bits that will indicate those immediate contexts where the TLAS
-    ///             will actually be used. Do not set unncessary bits as this will result in extra overhead.
+    ///             will actually be used. Do not set unnecessary bits as this will result in extra overhead.
     Uint64                    ImmediateContextMask    DEFAULT_INITIALIZER(1);
 
 #if DILIGENT_CPP_INTERFACE

--- a/Graphics/GraphicsEngine/src/RenderDeviceBase.cpp
+++ b/Graphics/GraphicsEngine/src/RenderDeviceBase.cpp
@@ -97,11 +97,11 @@ DeviceFeatures EnableDeviceFeatures(const DeviceFeatures& SupportedFeatures,
     ENABLE_FEATURE(PixelUAVWritesAndAtomics,          "Pixel UAV writes and atomics are");
     ENABLE_FEATURE(TextureUAVExtendedFormats,         "Texture UAV extended formats are");
     ENABLE_FEATURE(ShaderFloat16,                     "16-bit float shader operations are");
-    ENABLE_FEATURE(ResourceBuffer16BitAccess,         "16-bit resoure buffer access is");
+    ENABLE_FEATURE(ResourceBuffer16BitAccess,         "16-bit resource buffer access is");
     ENABLE_FEATURE(UniformBuffer16BitAccess,          "16-bit uniform buffer access is");
     ENABLE_FEATURE(ShaderInputOutput16,               "16-bit shader inputs/outputs are");
     ENABLE_FEATURE(ShaderInt8,                        "8-bit int shader operations are");
-    ENABLE_FEATURE(ResourceBuffer8BitAccess,          "8-bit resoure buffer access is");
+    ENABLE_FEATURE(ResourceBuffer8BitAccess,          "8-bit resource buffer access is");
     ENABLE_FEATURE(UniformBuffer8BitAccess,           "8-bit uniform buffer access is");
     ENABLE_FEATURE(ShaderResourceRuntimeArray,        "Shader resource runtime array is");
     ENABLE_FEATURE(WaveOp,                            "Wave operations are");

--- a/Graphics/GraphicsEngineD3D12/src/DeviceContextD3D12Impl.cpp
+++ b/Graphics/GraphicsEngineD3D12/src/DeviceContextD3D12Impl.cpp
@@ -2119,7 +2119,7 @@ void DeviceContextD3D12Impl::GenerateMips(ITextureView* pTexView)
         if (PSODesc.IsComputePipeline() || PSODesc.IsRayTracingPipeline())
         {
             // Mips generator will set its own compute pipeline, root signature and root resources.
-            // We need to invalidate curent PSO and reset it afterwards.
+            // We need to invalidate current PSO and reset it afterwards.
             pCurrPSO = m_pPipelineState;
             m_pPipelineState.Release();
             m_ComputeResources.pd3d12RootSig = nullptr;

--- a/Graphics/GraphicsEngineOpenGL/src/GLContextWindows.cpp
+++ b/Graphics/GraphicsEngineOpenGL/src/GLContextWindows.cpp
@@ -218,7 +218,7 @@ GLContext::GLContext(const EngineGLCreateInfo& InitAttribs,
     DevType    = RENDER_DEVICE_TYPE_GL;
     APIVersion = Version{MajorVersion, MinorVersion};
     VERIFY(static_cast<int>(APIVersion.Major) == MajorVersion && static_cast<int>(APIVersion.Minor) == MinorVersion,
-           "Not enought bits to store version number");
+           "Not enough bits to store version number");
 }
 
 GLContext::~GLContext()

--- a/Graphics/GraphicsEngineVulkan/include/DeviceContextVkImpl.hpp
+++ b/Graphics/GraphicsEngineVulkan/include/DeviceContextVkImpl.hpp
@@ -603,7 +603,7 @@ private:
 
     // Command pools for every queue family
     std::unique_ptr<std::unique_ptr<VulkanUtilities::VulkanCommandBufferPool>[]> m_QueueFamilyCmdPools;
-    // Command pool for the familiy for which we are recording commands
+    // Command pool for the family for which we are recording commands
     VulkanUtilities::VulkanCommandBufferPool* m_CmdPool = nullptr;
 
     VulkanUploadHeap              m_UploadHeap;

--- a/Graphics/GraphicsEngineVulkan/src/VulkanUtilities/VulkanSyncObjectManager.cpp
+++ b/Graphics/GraphicsEngineVulkan/src/VulkanUtilities/VulkanSyncObjectManager.cpp
@@ -119,7 +119,7 @@ void VulkanSyncObjectManager::Recycle(VkFenceType vkFence, bool IsUnsignaled)
 {
     if (!IsUnsignaled)
     {
-        // Acces to vkFence must be externally synchronized, we assume that vkFence is not used anywhere else.
+        // Access to vkFence must be externally synchronized, we assume that vkFence is not used anywhere else.
         vkResetFences(m_LogicalDevice.GetVkDevice(), 1, &vkFence.Value);
     }
 

--- a/Graphics/GraphicsTools/interface/DynamicTextureAtlas.h
+++ b/Graphics/GraphicsTools/interface/DynamicTextureAtlas.h
@@ -175,8 +175,8 @@ struct DynamicTextureAtlasCreateInfo
     /// When alignment is zero, the atlas may allocate the region in any suitable location.
     ///
     /// When alignment is non-zero, the region placement is aligned as follows:
-    /// - If min(Widht, Height) <= MinAlignment, the region placement is aligned by MinAlignment
-    /// - If min(Widht, Height) > MinAlignment, the alignment is doubled until it satisfies
+    /// - If min(Width, Height) <= MinAlignment, the region placement is aligned by MinAlignment
+    /// - If min(Width, Height) > MinAlignment, the alignment is doubled until it satisfies
     ///   the requirement above.
     ///
     /// Examples (when MinAlignment equals 64):
@@ -185,7 +185,7 @@ struct DynamicTextureAtlasCreateInfo
     /// - A 96x192 region will be aligned by 128 (it may be placed at e.g. (128, 256))
     /// - A 2048x1024 region will be aligned by 1024 (it may be placed at e.g. (1024, 0))
     ///
-    /// Note that if minimum alignemnt is zero, the region placement will not be aligned at all,
+    /// Note that if minimum alignment is zero, the region placement will not be aligned at all,
     /// which may result in biasing issues in coarser mip levels. For example, if 128x128
     /// region is placed at (4, 12) coordinates in the atlas (i.e. R = [4, 132] x [12, 140]), all
     /// mip levels of R starting with level 3 will not be aligned with the mip 0.

--- a/README.md
+++ b/README.md
@@ -449,7 +449,7 @@ classification of shader variables:
 
 * **Static variables** (`SHADER_RESOURCE_VARIABLE_TYPE_STATIC`) are variables that are expected to be set only once.
   They may not be changed once a resource is bound to the variable. Such variables are intended to hold global constants such 
-  as camera attributes or global light attributes constant buffers. Note that it is the *resource binding* that may not chage,
+  as camera attributes or global light attributes constant buffers. Note that it is the *resource binding* that may not change,
   while the contents of the resource is allowed to change according to its usage.
 * **Mutable variables** (`SHADER_RESOURCE_VARIABLE_TYPE_MUTABLE`) define resources that are expected to change on a per-material frequency.
   Examples may include diffuse textures, normal maps etc. Again updates to the contents of the resource are orthogobal

--- a/Tests/DiligentCoreAPITest/src/QueryTest.cpp
+++ b/Tests/DiligentCoreAPITest/src/QueryTest.cpp
@@ -412,11 +412,11 @@ TEST_F(QueryTest, Timestamp)
 
         RefCntAutoPtr<IQuery> pQueryStart;
         pDevice->CreateQuery(queryDesc, &pQueryStart);
-        ASSERT_NE(pQueryStart, nullptr) << "Failed to create tiemstamp query";
+        ASSERT_NE(pQueryStart, nullptr) << "Failed to create timestamp query";
 
         RefCntAutoPtr<IQuery> pQueryEnd;
         pDevice->CreateQuery(queryDesc, &pQueryEnd);
-        ASSERT_NE(pQueryEnd, nullptr) << "Failed to create tiemstamp query";
+        ASSERT_NE(pQueryEnd, nullptr) << "Failed to create timestamp query";
 
         for (Uint32 frame = 0; frame < sm_NumFrames; ++frame)
         {


### PR DESCRIPTION
Found via `codespell -q 3 -S ./ThirdParty,*.gltf -L boundimg,delimeter,delimeters,inout,lod,pres`