### PR TITLE
check if Vulkan_LIBRARY defined, before using it

### DIFF
--- a/Graphics/GraphicsEngineVulkan/CMakeLists.txt
+++ b/Graphics/GraphicsEngineVulkan/CMakeLists.txt
@@ -176,7 +176,7 @@ endif()
 if(PLATFORM_WIN32)
     # find Vulkan SDK
     find_package(Vulkan)
-    if(Vulkan_FOUND)
+    if(Vulkan_FOUND AND DEFINED ${Vulkan_LIBRARY})
         get_filename_component(VulkanSDKPath ${Vulkan_LIBRARY} DIRECTORY)
         set(VulkanSDKPath "${VulkanSDKPath}/..")
         if(NOT EXISTS "${VulkanSDKPath}")


### PR DESCRIPTION
I am building Vulkan libs from sources and I don't have dxcompiler lib and I also don't have Vulkan_LIBRARY  variable defined.
Therefore, I am getting an error get_filename_component got invalid number of arguments.

In any case, it's good to check if variable exists before actually using it