### PR TITLE
Fix various typos

### DIFF
--- a/Common/interface/ThreadPool.hpp
+++ b/Common/interface/ThreadPool.hpp
@@ -192,7 +192,7 @@ public:
     /// \param[in] ThreadId    - Id of the thread that is running this task.
     /// \param[in] WaitForTask - whether the function should wait for the next task:
     ///                          - if true, the function will block the thread until the next task
-    ///                            is retreived from the queue and processed.
+    ///                            is retrieved from the queue and processed.
     ///                          - if false, the function will return immediately if there are no
     ///                            tasks in the queue.
     ///
@@ -312,7 +312,7 @@ public:
                     break;
 
                 default:
-                    UNEXPECTED("Unexpected task satus");
+                    UNEXPECTED("Unexpected task status");
             }
         }
 #endif

--- a/Common/src/ThreadPool.cpp
+++ b/Common/src/ThreadPool.cpp
@@ -99,7 +99,7 @@ public:
                 auto front = m_TasksQueue.begin();
                 pTask      = std::move(front->second);
                 // NB: we must increment the running task counter while holding the lock and
-                //     before removing the taks from the queue, otherwise WaitForAllTasks() may
+                //     before removing the task from the queue, otherwise WaitForAllTasks() may
                 //     miss the task.
                 m_NumRunningTasks.fetch_add(1);
                 m_TasksQueue.erase(front);

--- a/Graphics/Archiver/interface/ArchiverFactory.h
+++ b/Graphics/Archiver/interface/ArchiverFactory.h
@@ -93,7 +93,7 @@ DILIGENT_BEGIN_INTERFACE(IArchiverFactory, IObject)
                                           IArchive*                 pDeviceArchive,
                                           IFileStream*              pStream) CONST PURE;
 
-    /// Print archive content for debuging and validating.
+    /// Print archive content for debugging and validating.
     VIRTUAL Bool METHOD(PrintArchiveContent)(THIS_
                                              IArchive* pArchive) CONST PURE;
 

--- a/Graphics/GraphicsEngine/interface/DeviceContext.h
+++ b/Graphics/GraphicsEngine/interface/DeviceContext.h
@@ -1830,7 +1830,7 @@ struct BindSparseResourceMemoryAttribs
 
     /// An array of NumWaitFences fences to wait.
 
-    /// \remarks The context will wait untill all fences have reached the values
+    /// \remarks The context will wait until all fences have reached the values
     ///          specified in pWaitFenceValues.
     IFence**      ppWaitFences       DEFAULT_INITIALIZER(nullptr);
 
@@ -1886,7 +1886,7 @@ DEFINE_FLAG_ENUM_OPERATORS(STATE_TRANSITION_FLAGS);
 /// Resource state transition barrier description
 struct StateTransitionDesc
 {
-    /// Previous resource for aliasing transiton.
+    /// Previous resource for aliasing transition.
     ///
     /// This member is only used for aliasing transition (STATE_TRANSITION_FLAG_ALIASING flag is set),
     /// and ignored otherwise, and must point to a texture or a buffer object.

--- a/Graphics/GraphicsEngine/interface/GraphicsTypes.h
+++ b/Graphics/GraphicsEngine/interface/GraphicsTypes.h
@@ -1929,7 +1929,7 @@ DILIGENT_TYPED_ENUM(VALIDATION_LEVEL, Uint8)
 };
 
 
-/// Texture properites
+/// Texture properties
 struct TextureProperties
 {
     /// Maximum dimension (width) of a 1D texture, or 0 if 1D textures are not supported.
@@ -3227,7 +3227,7 @@ struct EngineCreateInfo
     /// A pointer to the array of NumImmediateContexts structs describing immediate
     /// device contexts to create. See Diligent::ImmediateContextCreateInfo.
 
-    /// Every immediate device contexts encompases a command queue of a specific type.
+    /// Every immediate device contexts encompasses a command queue of a specific type.
     /// It may record commands directly or execute command lists recorded by deferred contexts.
     ///
     /// If not specified, single graphics context will be created.

--- a/Graphics/GraphicsEngine/src/RenderDeviceBase.cpp
+++ b/Graphics/GraphicsEngine/src/RenderDeviceBase.cpp
@@ -114,7 +114,7 @@ DeviceFeatures EnableDeviceFeatures(const DeviceFeatures& SupportedFeatures,
     // clang-format on
 #undef ENABLE_FEATURE
 
-    ASSERT_SIZEOF(Diligent::DeviceFeatures, 39, "Did you add a new feature to DeviceFeatures? Please handle its satus here (if necessary).");
+    ASSERT_SIZEOF(Diligent::DeviceFeatures, 39, "Did you add a new feature to DeviceFeatures? Please handle its status here (if necessary).");
 
     return EnabledFeatures;
 }

--- a/Graphics/GraphicsEngineD3D11/src/EngineFactoryD3D11.cpp
+++ b/Graphics/GraphicsEngineD3D11/src/EngineFactoryD3D11.cpp
@@ -441,7 +441,7 @@ GraphicsAdapterInfo EngineFactoryD3D11Impl::GetGraphicsAdapterInfo(void*        
         }
         Features.ShaderFloat16 = ShaderFloat16Supported ? DEVICE_FEATURE_STATE_ENABLED : DEVICE_FEATURE_STATE_DISABLED;
     }
-    ASSERT_SIZEOF(Features, 39, "Did you add a new feature to DeviceFeatures? Please handle its satus here.");
+    ASSERT_SIZEOF(Features, 39, "Did you add a new feature to DeviceFeatures? Please handle its status here.");
 
     // Texture properties
     {

--- a/Graphics/GraphicsEngineD3D12/interface/TextureD3D12.h
+++ b/Graphics/GraphicsEngineD3D12/interface/TextureD3D12.h
@@ -79,7 +79,7 @@ DILIGENT_END_INTERFACE
 #    define ITextureD3D12_SetD3D12ResourceState(This, ...) CALL_IFACE_METHOD(TextureD3D12, SetD3D12ResourceState, This, __VA_ARGS__)
 #    define ITextureD3D12_GetD3D12ResourceState(This)      CALL_IFACE_METHOD(TextureD3D12, GetD3D12ResourceState, This)
 
-// clang-format ons
+// clang-format on
 
 #endif
 

--- a/Graphics/GraphicsEngineD3D12/src/EngineFactoryD3D12.cpp
+++ b/Graphics/GraphicsEngineD3D12/src/EngineFactoryD3D12.cpp
@@ -1060,7 +1060,7 @@ GraphicsAdapterInfo EngineFactoryD3D12Impl::GetGraphicsAdapterInfo(void*        
         ASSERT_SIZEOF(DrawCommandProps, 12, "Did you add a new member to DrawCommandProperties? Please initialize it here.");
     }
 
-    ASSERT_SIZEOF(DeviceFeatures, 39, "Did you add a new feature to DeviceFeatures? Please handle its satus here.");
+    ASSERT_SIZEOF(DeviceFeatures, 39, "Did you add a new feature to DeviceFeatures? Please handle its status here.");
 
     return AdapterInfo;
 }

--- a/Graphics/GraphicsEngineD3D12/src/PipelineResourceSignatureD3D12Impl.cpp
+++ b/Graphics/GraphicsEngineD3D12/src/PipelineResourceSignatureD3D12Impl.cpp
@@ -330,19 +330,19 @@ void PipelineResourceSignatureD3D12Impl::AllocateRootParameters(const bool IsSer
         else
         {
             DEV_CHECK_ERR(pAttrib->Register == Register,
-                          "Deserialzied shader register (", pAttrib->Register, ") is invalid: ", Register, " is expected.");
+                          "Deserialized shader register (", pAttrib->Register, ") is invalid: ", Register, " is expected.");
             DEV_CHECK_ERR(pAttrib->Space == Space,
-                          "Deserialzied shader space (", pAttrib->Space, ") is invalid: ", Space, " is expected.");
+                          "Deserialized shader space (", pAttrib->Space, ") is invalid: ", Space, " is expected.");
             DEV_CHECK_ERR(pAttrib->SamplerInd == AssignedSamplerInd,
-                          "Deserialzied sampler index (", pAttrib->SamplerInd, ") is invalid: ", AssignedSamplerInd, " is expected.");
+                          "Deserialized sampler index (", pAttrib->SamplerInd, ") is invalid: ", AssignedSamplerInd, " is expected.");
             DEV_CHECK_ERR(pAttrib->SRBRootIndex == SRBRootIndex,
-                          "Deserialzied root index (", pAttrib->SRBRootIndex, ") is invalid: ", SRBRootIndex, " is expected.");
+                          "Deserialized root index (", pAttrib->SRBRootIndex, ") is invalid: ", SRBRootIndex, " is expected.");
             DEV_CHECK_ERR(pAttrib->SRBOffsetFromTableStart == SRBOffsetFromTableStart,
-                          "Deserialzied offset from table start (", pAttrib->SRBOffsetFromTableStart, ") is invalid: ", SRBOffsetFromTableStart, " is expected.");
+                          "Deserialized offset from table start (", pAttrib->SRBOffsetFromTableStart, ") is invalid: ", SRBOffsetFromTableStart, " is expected.");
             DEV_CHECK_ERR(pAttrib->SigRootIndex == SigRootIndex,
-                          "Deserialzied signature root index (", pAttrib->SigRootIndex, ") is invalid: ", SigRootIndex, " is expected.");
+                          "Deserialized signature root index (", pAttrib->SigRootIndex, ") is invalid: ", SigRootIndex, " is expected.");
             DEV_CHECK_ERR(pAttrib->SigOffsetFromTableStart == SigOffsetFromTableStart,
-                          "Deserialzied signature offset from table start (", pAttrib->SigOffsetFromTableStart, ") is invalid: ", SigOffsetFromTableStart, " is expected.");
+                          "Deserialized signature offset from table start (", pAttrib->SigOffsetFromTableStart, ") is invalid: ", SigOffsetFromTableStart, " is expected.");
             DEV_CHECK_ERR(pAttrib->IsImmutableSamplerAssigned() == (SrcImmutableSamplerInd != InvalidImmutableSamplerIndex),
                           "Deserialized immutable sampler flag is invalid");
             DEV_CHECK_ERR(pAttrib->GetD3D12RootParamType() == d3d12RootParamType,

--- a/Graphics/GraphicsEngineD3D12/src/RenderDeviceD3D12Impl.cpp
+++ b/Graphics/GraphicsEngineD3D12/src/RenderDeviceD3D12Impl.cpp
@@ -107,7 +107,7 @@ CComPtr<ID3D12Heap> CreateDummyNVApiHeap(ID3D12Device* pd3d12Device)
 
     // From NVAPI docs:
     //      pHeap is necessary when bTexture2DArrayMipPack is true.
-    //      pHeap can be any heap and this API doens't change anything to it.
+    //      pHeap can be any heap and this API doesn't change anything to it.
     //
     // On D3D12_RESOURCE_HEAP_TIER_1 hardware, we need to specify the heap usage. Use NON_RT_DS_TEXTURES as the
     // most logical for sparse 2D arrays (the documentation says that pHeap can be any heap anyway).

--- a/Graphics/GraphicsEngineMetal/interface/TextureMtl.h
+++ b/Graphics/GraphicsEngineMetal/interface/TextureMtl.h
@@ -66,7 +66,7 @@ DILIGENT_END_INTERFACE
 #    define ITextureMtl_GetMtlResource(This) CALL_IFACE_METHOD(TextureMtl, GetMtlResource, This)
 #    define ITextureMtl_GetMtlHeap(This)     CALL_IFACE_METHOD(TextureMtl, GetMtlHeap,     This)
 
-// clang-format ons
+// clang-format on
 #endif
 
 DILIGENT_END_NAMESPACE // namespace Diligent

--- a/Graphics/GraphicsEngineMetal/interface/TextureViewMtl.h
+++ b/Graphics/GraphicsEngineMetal/interface/TextureViewMtl.h
@@ -60,7 +60,7 @@ DILIGENT_END_INTERFACE
 
 #    define ITextureViewMtl_GetMtlTexture(This) CALL_IFACE_METHOD(TextureViewMtl, GetMtlTexture, This)
 
-// clang-format ons
+// clang-format on
 
 #endif
 

--- a/Graphics/GraphicsEngineNextGenBase/include/RenderDeviceNextGenBase.hpp
+++ b/Graphics/GraphicsEngineNextGenBase/include/RenderDeviceNextGenBase.hpp
@@ -227,7 +227,7 @@ public:
             // not incremented while executing the command buffer (as is the case with Unity command queue).
 
             // As long as resources used by deferred contexts are not released before the command list
-            // is executed through immediate context, this stategy always works.
+            // is executed through immediate context, this strategy always works.
             Queue.ReleaseQueue.DiscardStaleResources(CmdBuffInfo.CmdBufferNumber, CmdBuffInfo.FenceValue);
         }
 

--- a/Graphics/GraphicsEngineOpenGL/include/GLObjectWrapper.hpp
+++ b/Graphics/GraphicsEngineOpenGL/include/GLObjectWrapper.hpp
@@ -106,7 +106,7 @@ public:
     {
         // This unique ID is used to unambiguously identify the object for
         // tracking purposes.
-        // Niether GL handle nor pointer could be safely used for this purpose
+        // Neither GL handle nor pointer could be safely used for this purpose
         // as both GL reuses released handles and the OS reuses released pointers
         return m_UniqueId.GetID();
     }

--- a/Graphics/GraphicsEngineOpenGL/src/GLContextEmscripten.cpp
+++ b/Graphics/GraphicsEngineOpenGL/src/GLContextEmscripten.cpp
@@ -40,7 +40,7 @@ GLContext::GLContext(const EngineGLCreateInfo& InitAttribs, RENDER_DEVICE_TYPE& 
         EmscriptenWebGLContextAttributes ContextAttributes = {};
         emscripten_webgl_init_context_attributes(&ContextAttributes);
 
-        // TODO: Intitialization params
+        // TODO: Initialization params
         ContextAttributes.depth        = true;
         ContextAttributes.majorVersion = 3;
         ContextAttributes.minorVersion = 0;

--- a/Graphics/GraphicsEngineOpenGL/src/RenderDeviceGLImpl.cpp
+++ b/Graphics/GraphicsEngineOpenGL/src/RenderDeviceGLImpl.cpp
@@ -992,7 +992,7 @@ void RenderDeviceGLImpl::InitAdapterInfo()
         m_AdapterInfo.Queues[0].TextureCopyGranularity[2] = 1;
     }
 
-    ASSERT_SIZEOF(DeviceFeatures, 39, "Did you add a new feature to DeviceFeatures? Please handle its satus here.");
+    ASSERT_SIZEOF(DeviceFeatures, 39, "Did you add a new feature to DeviceFeatures? Please handle its status here.");
 }
 
 void RenderDeviceGLImpl::FlagSupportedTexFormats()

--- a/Graphics/GraphicsEngineVulkan/interface/TextureViewVk.h
+++ b/Graphics/GraphicsEngineVulkan/interface/TextureViewVk.h
@@ -63,7 +63,7 @@ DILIGENT_END_INTERFACE
 
 #    define ITextureViewVk_GetVulkanImageView(This) CALL_IFACE_METHOD(TextureViewVk, GetVulkanImageView, This)
 
-// clang-format ons
+// clang-format on
 
 #endif
 

--- a/Graphics/GraphicsEngineVulkan/interface/TextureVk.h
+++ b/Graphics/GraphicsEngineVulkan/interface/TextureVk.h
@@ -78,7 +78,7 @@ DILIGENT_END_INTERFACE
 #    define ITextureVk_SetLayout(This, ...) CALL_IFACE_METHOD(TextureVk, SetLayout, This, __VA_ARGS__)
 #    define ITextureVk_GetLayout(This)      CALL_IFACE_METHOD(TextureVk, GetLayout, This)
 
-// clang-format ons
+// clang-format on
 
 #endif
 

--- a/Graphics/GraphicsEngineVulkan/src/EngineFactoryVk.cpp
+++ b/Graphics/GraphicsEngineVulkan/src/EngineFactoryVk.cpp
@@ -1137,7 +1137,7 @@ void EngineFactoryVkImpl::CreateDeviceAndContextsVk(const EngineVkCreateInfo& En
                 LOG_ERROR_MESSAGE("Can not enable extended device features when VK_KHR_get_physical_device_properties2 extension is not supported by device");
         }
 
-        ASSERT_SIZEOF(Diligent::DeviceFeatures, 39, "Did you add a new feature to DeviceFeatures? Please handle its satus here.");
+        ASSERT_SIZEOF(Diligent::DeviceFeatures, 39, "Did you add a new feature to DeviceFeatures? Please handle its status here.");
 
         for (Uint32 i = 0; i < EngineCI.DeviceExtensionCount; ++i)
         {

--- a/Graphics/GraphicsEngineVulkan/src/PipelineResourceSignatureVkImpl.cpp
+++ b/Graphics/GraphicsEngineVulkan/src/PipelineResourceSignatureVkImpl.cpp
@@ -334,7 +334,7 @@ void PipelineResourceSignatureVkImpl::CreateSetLayouts(const bool IsSerialized)
                           "Deserialized array size (", pAttribs->ArraySize, ") is invalid: ", ResDesc.ArraySize, " is expected.");
             DEV_CHECK_ERR(pAttribs->GetDescriptorType() == DescrType, "Deserialized descriptor type in invalid");
             DEV_CHECK_ERR(pAttribs->DescrSet == DSMapping[SetId],
-                          "Deserialized descriotor set (", pAttribs->DescrSet, ") is invalid: ", DSMapping[SetId], " is expected.");
+                          "Deserialized descriptor set (", pAttribs->DescrSet, ") is invalid: ", DSMapping[SetId], " is expected.");
             DEV_CHECK_ERR(pAttribs->IsImmutableSamplerAssigned() == (pVkImmutableSamplers != nullptr), "Immutable sampler flag is invalid");
             DEV_CHECK_ERR(pAttribs->SRBCacheOffset == CacheGroupOffsets[CacheGroup],
                           "SRB cache offset (", pAttribs->SRBCacheOffset, ") is invalid: ", CacheGroupOffsets[CacheGroup], " is expected.");

--- a/Graphics/GraphicsEngineVulkan/src/VulkanTypeConversions.cpp
+++ b/Graphics/GraphicsEngineVulkan/src/VulkanTypeConversions.cpp
@@ -1263,7 +1263,7 @@ static VkAccessFlags ResourceStateFlagToVkAccessFlags(RESOURCE_STATE StateFlag)
         case RESOURCE_STATE_BUILD_AS_READ:     return VK_ACCESS_SHADER_READ_BIT; // for vertex, index, transform, AABB, instance buffers
         case RESOURCE_STATE_BUILD_AS_WRITE:    return VK_ACCESS_ACCELERATION_STRUCTURE_READ_BIT_KHR | VK_ACCESS_ACCELERATION_STRUCTURE_WRITE_BIT_KHR; // for scratch buffer
         case RESOURCE_STATE_RAY_TRACING:       return VK_ACCESS_SHADER_READ_BIT; // for SBT
-        case RESOURCE_STATE_COMMON:            return 0; // COMMON state must be used for queue to queue transition (linke in D3D12), queue to queue synchronization via semaphore creates a memory dependency
+        case RESOURCE_STATE_COMMON:            return 0; // COMMON state must be used for queue to queue transition (linked in D3D12), queue to queue synchronization via semaphore creates a memory dependency
         case RESOURCE_STATE_SHADING_RATE:      return VK_ACCESS_FRAGMENT_DENSITY_MAP_READ_BIT_EXT | VK_ACCESS_FRAGMENT_SHADING_RATE_ATTACHMENT_READ_BIT_KHR;
             // clang-format on
 
@@ -2018,7 +2018,7 @@ DeviceFeatures VkFeaturesToDeviceFeatures(uint32_t                              
     Features.DurationQueries        = DEVICE_FEATURE_STATE_DISABLED;
 #endif
 
-    ASSERT_SIZEOF(DeviceFeatures, 39, "Did you add a new feature to DeviceFeatures? Please handle its satus here (if necessary).");
+    ASSERT_SIZEOF(DeviceFeatures, 39, "Did you add a new feature to DeviceFeatures? Please handle its status here (if necessary).");
 
     return Features;
 }

--- a/Graphics/GraphicsTools/interface/DynamicBuffer.hpp
+++ b/Graphics/GraphicsTools/interface/DynamicBuffer.hpp
@@ -60,7 +60,7 @@ struct DynamicBufferCreateInfo
     ///     multiple of the block size.
     Uint32 MemoryPageSize = 64 << 10;
 
-    /// When Desc.Usage == USAGE_SPARSE, the virual size of the sparse buffer;
+    /// When Desc.Usage == USAGE_SPARSE, the virtual size of the sparse buffer;
     /// ignored otherwise.
     Uint64 VirualSize = Uint64{1} << Uint64{30};
 };

--- a/Graphics/GraphicsTools/interface/GraphicsUtilities.h
+++ b/Graphics/GraphicsTools/interface/GraphicsUtilities.h
@@ -108,7 +108,7 @@ struct ComputeMipLevelAttribs
     /// Alpha cutoff value.
     ///
     /// \remarks
-    ///     When AlphaCutoff is not 0, alpha channel is remaped as follows:
+    ///     When AlphaCutoff is not 0, alpha channel is remapped as follows:
     ///         A_new = max(A_old; 1/3 * A_old + 2/3 * AlphaCutoff)
     float AlphaCutoff          DEFAULT_INITIALIZER(0);
 

--- a/Graphics/HLSL2GLSLConverterLib/src/HLSL2GLSLConverterImpl.cpp
+++ b/Graphics/HLSL2GLSLConverterLib/src/HLSL2GLSLConverterImpl.cpp
@@ -637,7 +637,7 @@ HLSL2GLSLConverterImpl::HLSL2GLSLConverterImpl()
     DEFINE_STUB("GatherCmp_3", "samplerCubeArrayShadow", "GatherCmp", 3); // GatherCmp( SmplerCmp, Location, CompareValue )
 
     // All load operations should return the same number of components as specified
-    // in texture declaraion, so use swizzling. Example:
+    // in texture declaration, so use swizzling. Example:
     // Texture3D<int2> Tex3D;
     // ...
     // Tex3D.Load(i4Location) -> LoadTex3D_1(Tex3D, i4Location)_SWIZZLE2
@@ -1747,7 +1747,7 @@ void HLSL2GLSLConverterImpl::ConversionStream::ParseSamplers(TokenListType::iter
                     break;
                 }
 
-                // Go to the next sampler declaraion or statement end
+                // Go to the next sampler declaration or statement end
                 while (Token != m_Tokens.end() && Token->Type != TokenType::Comma && Token->Type != TokenType::Semicolon)
                     ++Token;
                 VERIFY_PARSER_STATE(Token, Token != m_Tokens.end(), "Unexpected EOF while parsing ", SamplerType, " declaration");
@@ -5065,7 +5065,7 @@ String HLSL2GLSLConverterImpl::ConversionStream::Convert(const Char* EntryPoint,
                     if (TmpToken != m_Tokens.end() && TmpToken->Type == TokenType::OpenBrace)
                     {
                         // We need to go through the function argument
-                        // list as there may be texture declaraions
+                        // list as there may be texture declarations
                         ++Token;
                         // float4 Func ( in float2 f2UV,
                         //               ^

--- a/Tests/DiligentCoreAPITest/include/RayTracingTestConstants.hpp
+++ b/Tests/DiligentCoreAPITest/include/RayTracingTestConstants.hpp
@@ -156,7 +156,7 @@ namespace TestingConstants
         static_assert(_countof(Primitives) == 9, "Update array size in shaders");
         static_assert(_countof(Indices) % 3 == 0, "Invalid index count");
         static_assert(_countof(Indices) / 3 == _countof(Primitives), "Primitive count mismatch");
-        static_assert(ShaderRecordSize == 32, "bust be 32 bytes");
+        static_assert(ShaderRecordSize == 32, "must be 32 bytes");
 
     } // namespace MultiGeometry
 

--- a/Tests/DiligentCoreTest/src/Common/ThreadPoolTest.cpp
+++ b/Tests/DiligentCoreTest/src/Common/ThreadPoolTest.cpp
@@ -224,7 +224,7 @@ TEST(Common_ThreadPool, RemoveTask)
         EXPECT_TRUE(res);
     }
 
-    // Wait unitl tasks are started
+    // Wait until tasks are started
     for (auto& Task : WaitTasks)
     {
         Task->WaitUntilRunning();

--- a/Tests/GPUTestFramework/src/Vulkan/TestingEnvironmentVk.cpp
+++ b/Tests/GPUTestFramework/src/Vulkan/TestingEnvironmentVk.cpp
@@ -371,7 +371,7 @@ VkRenderPassCreateInfo TestingEnvironmentVk::GetRenderPassCreateInfo(
 VkShaderModule TestingEnvironmentVk::CreateShaderModule(const SHADER_TYPE ShaderType, const std::string& ShaderSource)
 {
 #if DILIGENT_NO_GLSLANG
-    LOG_ERROR("GLSLang was not built. Shader compilaton is not possible.");
+    LOG_ERROR("GLSLang was not built. Shader compilation is not possible.");
     return VK_NULL_HANDLE;
 #else
     GLSLangUtils::GLSLtoSPIRVAttribs Attribs;


### PR DESCRIPTION
Found via `codespell -q 3 -S ./ThirdParty,*.gltf -L boundimg,delimeter,delimeters,inout,lod,pres,ser,wser`