### PR TITLE
Use copied GeometryName when creating BLAS instances.

### DIFF
--- a/Graphics/GraphicsEngine/src/BottomLevelASBase.cpp
+++ b/Graphics/GraphicsEngine/src/BottomLevelASBase.cpp
@@ -126,7 +126,8 @@ void CopyBLASGeometryDesc(const BottomLevelASDesc& SrcDesc,
         for (Uint32 i = 0; i < SrcDesc.TriangleCount; ++i)
         {
             const auto* SrcGeoName     = SrcDesc.pTriangles[i].GeometryName;
-            pTriangles[i].GeometryName = MemPool.CopyString(SrcGeoName);
+            const auto* GeoName        = MemPool.CopyString(SrcGeoName);
+            pTriangles[i].GeometryName = GeoName;
 
             Uint32 ActualIndex = INVALID_INDEX;
             if (pSrcNameToIndex)
@@ -136,7 +137,7 @@ void CopyBLASGeometryDesc(const BottomLevelASDesc& SrcDesc,
                 ActualIndex = iter->second.ActualIndex;
             }
 
-            bool IsUniqueName = DstNameToIndex.emplace(pTriangles[i].GeometryName, BLASGeomIndex{i, ActualIndex}).second;
+            bool IsUniqueName = DstNameToIndex.emplace(GeoName, BLASGeomIndex{i, ActualIndex}).second;
             if (!IsUniqueName)
                 LOG_ERROR_AND_THROW("Geometry name '", SrcGeoName, "' is not unique");
         }
@@ -161,7 +162,8 @@ void CopyBLASGeometryDesc(const BottomLevelASDesc& SrcDesc,
         for (Uint32 i = 0; i < SrcDesc.BoxCount; ++i)
         {
             const auto* SrcGeoName = SrcDesc.pBoxes[i].GeometryName;
-            pBoxes[i].GeometryName = MemPool.CopyString(SrcGeoName);
+            const auto* GeoName    = MemPool.CopyString(SrcGeoName);
+            pBoxes[i].GeometryName = GeoName;
 
             Uint32 ActualIndex = INVALID_INDEX;
             if (pSrcNameToIndex)
@@ -171,7 +173,7 @@ void CopyBLASGeometryDesc(const BottomLevelASDesc& SrcDesc,
                 ActualIndex = iter->second.ActualIndex;
             }
 
-            bool IsUniqueName = DstNameToIndex.emplace(pBoxes[i].GeometryName, BLASGeomIndex{i, ActualIndex}).second;
+            bool IsUniqueName = DstNameToIndex.emplace(GeoName, BLASGeomIndex{i, ActualIndex}).second;
             if (!IsUniqueName)
                 LOG_ERROR_AND_THROW("Geometry name '", SrcGeoName, "' is not unique");
         }

--- a/Graphics/GraphicsEngine/src/BottomLevelASBase.cpp
+++ b/Graphics/GraphicsEngine/src/BottomLevelASBase.cpp
@@ -136,7 +136,7 @@ void CopyBLASGeometryDesc(const BottomLevelASDesc& SrcDesc,
                 ActualIndex = iter->second.ActualIndex;
             }
 
-            bool IsUniqueName = DstNameToIndex.emplace(SrcGeoName, BLASGeomIndex{i, ActualIndex}).second;
+            bool IsUniqueName = DstNameToIndex.emplace(pTriangles[i].GeometryName, BLASGeomIndex{i, ActualIndex}).second;
             if (!IsUniqueName)
                 LOG_ERROR_AND_THROW("Geometry name '", SrcGeoName, "' is not unique");
         }

--- a/Graphics/GraphicsEngine/src/BottomLevelASBase.cpp
+++ b/Graphics/GraphicsEngine/src/BottomLevelASBase.cpp
@@ -171,7 +171,7 @@ void CopyBLASGeometryDesc(const BottomLevelASDesc& SrcDesc,
                 ActualIndex = iter->second.ActualIndex;
             }
 
-            bool IsUniqueName = DstNameToIndex.emplace(SrcGeoName, BLASGeomIndex{i, ActualIndex}).second;
+            bool IsUniqueName = DstNameToIndex.emplace(pBoxes[i].GeometryName, BLASGeomIndex{i, ActualIndex}).second;
             if (!IsUniqueName)
                 LOG_ERROR_AND_THROW("Geometry name '", SrcGeoName, "' is not unique");
         }


### PR DESCRIPTION
Use the copied name in pTriangles or pBoxes in the BottomLevelASDesc. This allows these values to come from C#. When used from there with P/Invoke the SrcGeoName string is controlled by the marshaller and will be deleted once the BLAS has been created. Later, when we go to use the BLAS, the name will have an invalid value. By using the copy that is already created we avoid this situation and don't need further complex management to keep these strings initialized.

I've been using this for a while on 2.4.g and now 2.5.2 and it does not have any negative impacts that I can see.