### PR TITLE
Incresease cmake_minimum_required to 3.19 (#402)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.6)
+cmake_minimum_required (VERSION 3.19)
 
 project(DiligentCore)
 


### PR DESCRIPTION
CMake 3.19+ is required for support of generator expressions matching multiple configurations.