### PR TITLE
Fix bind target in BufferGLImpl::UpdateData.

### DIFF
--- a/Graphics/GraphicsEngineOpenGL/src/BufferGLImpl.cpp
+++ b/Graphics/GraphicsEngineOpenGL/src/BufferGLImpl.cpp
@@ -224,13 +224,13 @@ void BufferGLImpl::UpdateData(GLContextState& CtxState, Uint64 Offset, Uint64 Si
         CtxState);
 
     // We must unbind VAO because otherwise we will break the bindings
-    constexpr bool ResetVAO = true;
-    CtxState.BindBuffer(GL_ARRAY_BUFFER, m_GlBuffer, ResetVAO);
+    const auto ResetVAO = m_BindTarget == GL_ARRAY_BUFFER || m_BindTarget == GL_ELEMENT_ARRAY_BUFFER;
+    CtxState.BindBuffer(m_BindTarget, m_GlBuffer, ResetVAO);
     // All buffer bind targets (GL_ARRAY_BUFFER, GL_ELEMENT_ARRAY_BUFFER etc.) relate to the same
     // kind of objects. As a result they are all equivalent from a transfer point of view.
-    glBufferSubData(GL_ARRAY_BUFFER, StaticCast<GLintptr>(Offset), StaticCast<GLsizeiptr>(Size), pData);
+    glBufferSubData(m_BindTarget, StaticCast<GLintptr>(Offset), StaticCast<GLsizeiptr>(Size), pData);
     CHECK_GL_ERROR("glBufferSubData() failed");
-    CtxState.BindBuffer(GL_ARRAY_BUFFER, GLObjectWrappers::GLBufferObj::Null(), ResetVAO);
+    CtxState.BindBuffer(m_BindTarget, GLObjectWrappers::GLBufferObj::Null(), ResetVAO);
 }
 
 


### PR DESCRIPTION
Using `GL_ARRAY_BUFFER` for index buffer causes this error on WebGL:

> bindBuffer: element array buffers can not be bound to a different target

I see no reason _not_ to use actual buffer type in UpdateData.