### PR TITLE
Make NEW_RC_OBJ useful outside of Diligent namespace.

### DIFF
--- a/Common/interface/RefCountedObjectImpl.hpp
+++ b/Common/interface/RefCountedObjectImpl.hpp
@@ -693,6 +693,6 @@ private:
 #endif
 };
 
-#define NEW_RC_OBJ(Allocator, Desc, Type, ...) MakeNewRCObj<Type, typename std::remove_reference<decltype(Allocator)>::type>(Allocator, Desc, __FILE__, __LINE__, ##__VA_ARGS__)
+#define NEW_RC_OBJ(Allocator, Desc, Type, ...) Diligent::MakeNewRCObj<Type, typename std::remove_reference<decltype(Allocator)>::type>(Allocator, Desc, __FILE__, __LINE__, ##__VA_ARGS__)
 
 } // namespace Diligent


### PR DESCRIPTION
without namespace qualifier, I have to make MakeNewRCObj visible in my namespace.