### PR TITLE
Add callback for OpenGL program linkage.

### DIFF
--- a/Graphics/GraphicsEngine/interface/PipelineState.h
+++ b/Graphics/GraphicsEngine/interface/PipelineState.h
@@ -717,6 +717,9 @@ struct PipelineStateCreateInfo
 typedef struct PipelineStateCreateInfo PipelineStateCreateInfo;
 
 
+/// Callback that is invoked after OpenGL program object is linked.
+typedef void(DILIGENT_CALL_TYPE* GLProgramLinkedCallbackType)(Uint32* ProgramObjects, Uint32 NumProgramObjects, void* pUserData);
+
 /// Graphics pipeline state initialization information.
 struct GraphicsPipelineStateCreateInfo DILIGENT_DERIVE(PipelineStateCreateInfo)
 
@@ -743,6 +746,13 @@ struct GraphicsPipelineStateCreateInfo DILIGENT_DERIVE(PipelineStateCreateInfo)
 
     /// Mesh shader to be used with the pipeline.
     IShader* pMS DEFAULT_INITIALIZER(nullptr);
+
+    /// OpenGL only: Callback that is executed when program(s) are linked.
+    /// It is allowed to modify CreateInfo in this callback.
+    GLProgramLinkedCallbackType GLProgramLinkedCallback DEFAULT_INITIALIZER(nullptr);
+
+    /// OpenGL only: user data for GLProgramLinkedCallback.
+    void* GLProgramLinkedCallbackUserData DEFAULT_INITIALIZER(nullptr);
 
 #if DILIGENT_CPP_INTERFACE
     bool operator==(const GraphicsPipelineStateCreateInfo& Rhs) const noexcept
@@ -775,6 +785,13 @@ struct ComputePipelineStateCreateInfo DILIGENT_DERIVE(PipelineStateCreateInfo)
 
     /// Compute shader to be used with the pipeline
     IShader* pCS DEFAULT_INITIALIZER(nullptr);
+
+    /// OpenGL only: Callback that is executed when program(s) are linked.
+    /// It is allowed to modify CreateInfo in this callback.
+    GLProgramLinkedCallbackType GLProgramLinkedCallback DEFAULT_INITIALIZER(nullptr);
+
+    /// OpenGL only: user data for GLProgramLinkedCallback.
+    void* GLProgramLinkedCallbackUserData DEFAULT_INITIALIZER(nullptr);
 
 #if DILIGENT_CPP_INTERFACE
     ComputePipelineStateCreateInfo() noexcept

--- a/Graphics/GraphicsEngine/src/PSOSerializer.cpp
+++ b/Graphics/GraphicsEngine/src/PSOSerializer.cpp
@@ -201,7 +201,7 @@ bool PSOSerializer<Mode>::SerializeCreateInfo(
 
     // Skip NodeMask
 
-    ASSERT_SIZEOF64(GraphicsPipelineStateCreateInfo, 344, "Did you add a new member to GraphicsPipelineStateCreateInfo? Please add serialization here.");
+    ASSERT_SIZEOF64(GraphicsPipelineStateCreateInfo, 360, "Did you add a new member to GraphicsPipelineStateCreateInfo? Please add serialization here.");
     ASSERT_SIZEOF64(LayoutElement, 40, "Did you add a new member to LayoutElement? Please add serialization here.");
 }
 
@@ -214,7 +214,7 @@ bool PSOSerializer<Mode>::SerializeCreateInfo(
 {
     return SerializeCreateInfo(Ser, static_cast<ConstQual<PipelineStateCreateInfo>&>(CreateInfo), PRSNames, Allocator);
 
-    ASSERT_SIZEOF64(ComputePipelineStateCreateInfo, 104, "Did you add a new member to ComputePipelineStateCreateInfo? Please add serialization here.");
+    ASSERT_SIZEOF64(ComputePipelineStateCreateInfo, 120, "Did you add a new member to ComputePipelineStateCreateInfo? Please add serialization here.");
 }
 
 template <SerializerMode Mode>

--- a/Graphics/GraphicsEngineOpenGL/src/PipelineStateGLImpl.cpp
+++ b/Graphics/GraphicsEngineOpenGL/src/PipelineStateGLImpl.cpp
@@ -245,6 +245,35 @@ void PipelineStateGLImpl::InitInternalObjects(const PSOCreateInfoType& CreateInf
     m_IsProgramPipelineSupported = DeviceInfo.Features.SeparablePrograms != DEVICE_FEATURE_STATE_DISABLED;
     m_NumPrograms                = m_IsProgramPipelineSupported ? static_cast<Uint8>(ShaderStages.size()) : 1;
 
+    // Link shader programs before initializing pipeline state so that callback can change CreateInfo
+    static const Uint32 MaxNumShaderStages = 5;
+    VERIFY(ShaderStages.size() <= MaxNumShaderStages, "Unexpected number of shader stages");
+
+    std::array<GLProgramObj, MaxNumShaderStages> GLPrograms{GLProgramObj{false}, GLProgramObj{false}, GLProgramObj{false}, GLProgramObj{false}, GLProgramObj{false}};
+    std::array<Uint32, MaxNumShaderStages>       GLProgramsHandles;
+
+    // Create programs.
+    if (m_IsProgramPipelineSupported)
+    {
+        for (size_t i = 0; i < ShaderStages.size(); ++i)
+        {
+            GLPrograms[i]        = GLProgramObj{ShaderGLImpl::LinkProgram(&ShaderStages[i], 1, true)};
+            GLProgramsHandles[i] = static_cast<GLuint>(GLPrograms[i]);
+        }
+    }
+    else
+    {
+        GLPrograms[0]        = ShaderGLImpl::LinkProgram(ShaderStages.data(), static_cast<Uint32>(ShaderStages.size()), false);
+        GLProgramsHandles[0] = static_cast<GLuint>(GLPrograms[0]);
+    }
+
+    // Patch CreateInfo if necessary.
+    if (CreateInfo.GLProgramLinkedCallback)
+    {
+        (*CreateInfo.GLProgramLinkedCallback)(&GLProgramsHandles[0], m_NumPrograms, CreateInfo.GLProgramLinkedCallbackUserData);
+        m_Desc.ResourceLayout = CreateInfo.PSODesc.ResourceLayout;
+    }
+
     FixedLinearAllocator MemPool{GetRawAllocator()};
 
     ReserveSpaceForPipelineDesc(CreateInfo, MemPool);
@@ -275,13 +304,13 @@ void PipelineStateGLImpl::InitInternalObjects(const PSOCreateInfoType& CreateInf
         for (size_t i = 0; i < ShaderStages.size(); ++i)
         {
             auto* pShaderGL  = ShaderStages[i];
-            m_GLPrograms[i]  = GLProgramObj{ShaderGLImpl::LinkProgram(&ShaderStages[i], 1, true)};
+            m_GLPrograms[i]  = std::move(GLPrograms[i]);
             m_ShaderTypes[i] = pShaderGL->GetDesc().ShaderType;
         }
     }
     else
     {
-        m_GLPrograms[0]  = ShaderGLImpl::LinkProgram(ShaderStages.data(), static_cast<Uint32>(ShaderStages.size()), false);
+        m_GLPrograms[0]  = std::move(GLPrograms[0]);
         m_ShaderTypes[0] = ActiveStages;
 
         m_GLPrograms[0].SetName(m_Desc.Name);


### PR DESCRIPTION
**Disclaimer:** I know that this code is an abomination. However, (1) it has functional impact that was crucial for me, (2) I would like to have this code visible and available for other people with similar issue.

If this issue is not resolved in the master branch of Diligent one way or another, my solution will be available in [this branch](https://github.com/rbfx/DiligentCore/tree/gl-hook) indefinetely for anyone to cherry-pick.

---

### My use case

- I have "dynamic" shaders which are compiled on demand in real time, instead of being generated and compiled in build time. On one hand, this is limitation of the legacy codebase. On the other hand, it enables some rare use cases, e.g. ShaderToy-like sandbox. Point is, *I must be able to compile shaders in runtime*.
- Shaders are authored in GLSL.
- For OpenGL backend, using glslang/SPIRV-Tools/SPIRV-Tools should be optional. It may be useful but it is also heavy, and I also saw weird internal crashes in Emscripten+glslang interaction. Point is, *I must be able to upload GLSL shaders to OpenGL backend of Diligent "as is"*.

### My problem

- I must be able to compile shaders in runtime.
- I must be able to upload GLSL shaders to OpenGL backend of Diligent "as is".
- How on Earth do I create Diligent PipelineState then?..

On one hand, I need to provide vertex layout and immutable samplers in order to fill `GraphicsPipelineStateCreateInfo` and create `IPipelineState`.

On the other hand, I have no idea what *are* the samplers and the vertex layout until I link the shader program... which happens during `IPipelineState` creation. (I am ignoring "separable programs" since it is an optional extension.)

Therefore, it is basically _impossible_ to use OpenGL backend of Diligent with arbitrary GLSL shader. I have to somehow deduce vertex input slots and samplers on my own from raw shader code.

### My solution

I added OpenGL-specific hook that let's me modify `GraphicsPipelineStateCreateInfo` or `ComputePipelineStateCreateInfo` *after* I initiated pipeline state creation and Diligent has linked the program. This way, I can at least write OpenGL-specific code and obtain all the information I need.

This... is ugly as hell. Thanks to OpenGL being retarded. However, it enables the use case that was outright _impossible_ before. And this hack is limited to OpenGL backend, so it doesn't contaminate the rest of the library.

It would be great to have better solution, but I couldn't come up with one.

PS: I am creating this PR to discuss this issue and to share my solution. I don't really care if this tweak goes to the upstream or not.