### PR TITLE
Fix compilation for alternately named base directories

### DIFF
--- a/Common/interface/ObjectsRegistry.hpp
+++ b/Common/interface/ObjectsRegistry.hpp
@@ -23,7 +23,7 @@
 #include <algorithm>
 #include <atomic>
 
-#include "../../../DiligentCore/Platforms/Basic/interface/DebugUtilities.hpp"
+#include "../../Platforms/Basic/interface/DebugUtilities.hpp"
 #include "RefCntAutoPtr.hpp"
 
 namespace Diligent


### PR DESCRIPTION
This fixes an issue that happens if one clones the repository into a folder called something other than DiligentCore.