### PR TITLE
Fix some clang errors that only happen in Release

### DIFF
--- a/Graphics/GraphicsEngineD3D11/include/DeviceContextD3D11Impl.hpp
+++ b/Graphics/GraphicsEngineD3D11/include/DeviceContextD3D11Impl.hpp
@@ -497,7 +497,9 @@ private:
     /// Strong references to committed D3D11 shaders
     CComPtr<ID3D11DeviceChild> m_CommittedD3DShaders[NumShaderTypes];
 
+#ifdef DILIGENT_DEVELOPMENT
     const D3D11_VALIDATION_FLAGS m_D3D11ValidationFlags;
+#endif
 
     FixedBlockMemoryAllocator m_CmdListAllocator;
 

--- a/Graphics/GraphicsEngineD3D11/src/DeviceContextD3D11Impl.cpp
+++ b/Graphics/GraphicsEngineD3D11/src/DeviceContextD3D11Impl.cpp
@@ -61,7 +61,9 @@ DeviceContextD3D11Impl::DeviceContextD3D11Impl(IReferenceCounters*          pRef
         Desc
     },
     m_pd3d11DeviceContext {pd3d11DeviceContext          },
+#ifdef DILIGENT_DEVELOPMENT
     m_D3D11ValidationFlags{EngineCI.D3D11ValidationFlags},
+#endif
     m_CmdListAllocator    {GetRawAllocator(), sizeof(CommandListD3D11Impl), 64}
 // clang-format on
 {

--- a/Graphics/GraphicsEngineD3D12/src/BottomLevelASD3D12Impl.cpp
+++ b/Graphics/GraphicsEngineD3D12/src/BottomLevelASD3D12Impl.cpp
@@ -80,6 +80,7 @@ BottomLevelASD3D12Impl::BottomLevelASD3D12Impl(IReferenceCounters*      pRefCoun
 
                 MaxPrimitiveCount += src.MaxPrimitiveCount;
             }
+            (void)MaxPrimitiveCount; // Suppress warning
             DEV_CHECK_ERR(MaxPrimitiveCount <= RTProps.MaxPrimitivesPerBLAS,
                           "Max primitive count (", MaxPrimitiveCount, ") exceeds device limit (", RTProps.MaxPrimitivesPerBLAS, ")");
         }
@@ -100,6 +101,7 @@ BottomLevelASD3D12Impl::BottomLevelASD3D12Impl(IReferenceCounters*      pRefCoun
 
                 MaxBoxCount += src.MaxBoxCount;
             }
+            (void)MaxBoxCount; // Suppress warning
             DEV_CHECK_ERR(MaxBoxCount <= RTProps.MaxPrimitivesPerBLAS,
                           "Max box count (", MaxBoxCount, ") exceeds device limit (", RTProps.MaxPrimitivesPerBLAS, ")");
         }


### PR DESCRIPTION
Noticed some extra clang warning-errors that only happen when you build a non-development build due to 3 variables that are only used for debug validation. Fixed the warnings.