### PR TITLE
Add USAGE_DYNAMIC support to DynamicBuffer

### DIFF
--- a/Graphics/GraphicsTools/src/DynamicBuffer.cpp
+++ b/Graphics/GraphicsTools/src/DynamicBuffer.cpp
@@ -161,7 +161,7 @@ void DynamicBuffer::InitBuffer(IRenderDevice* pDevice)
     }
 
     // NB: m_Desc.Usage may be changed by CreateSparseBuffer()
-    if (m_Desc.Usage == USAGE_DEFAULT && m_PendingSize > 0)
+    if ((m_Desc.Usage == USAGE_DEFAULT || m_Desc.Usage == USAGE_DYNAMIC) && m_PendingSize > 0)
     {
         auto Desc = m_Desc;
         Desc.Size = m_PendingSize;
@@ -299,6 +299,9 @@ IBuffer* DynamicBuffer::Resize(IRenderDevice*  pDevice,
                                Uint64          NewSize,
                                bool            DiscardContent)
 {
+    DEV_CHECK_ERR(m_Desc.Usage == USAGE_DYNAMIC && DiscardContent,
+                  "Buffer content must be discarded when resizing USAGE_DEFAULT buffer");
+
     if (m_Desc.Usage == USAGE_SPARSE)
     {
         DEV_CHECK_ERR(NewSize <= m_VirtualSize, "New size (", NewSize, ") exceeds the buffer virtual size (", m_VirtualSize, ").");


### PR DESCRIPTION
Tested using

```c++
	Diligent::BufferDesc VBDesc;
	VBDesc.Name = "RawrBox::Buffer:IMGUI::VERTEX";
	VBDesc.BindFlags = Diligent::BIND_VERTEX_BUFFER;
	VBDesc.Size = 1024 * sizeof(ImDrawVert);
	VBDesc.Usage = Diligent::USAGE_DYNAMIC;
	VBDesc.CPUAccessFlags = Diligent::CPU_ACCESS_WRITE;

	Diligent::DynamicBufferCreateInfo dynamicBuff;
	dynamicBuff.Desc = VBDesc;

	_pVB = std::make_unique<Diligent::DynamicBuffer>(renderer.device(), dynamicBuff);
```

Then resizing it later

```c++
uint64_t vtxSize = sizeof(ImDrawVert) * data->TotalVtxCount;
if (vtxSize > _pVB->GetDesc().Size) {
	_pVB->Resize(device, context, sizeof(ImDrawVert) * static_cast<uint64_t>(data->TotalVtxCount), true);
}
```

Had no issues, the only enforced require is discarding the content on resize, not sure if it's possible to copy it over