### PR TITLE
Fix return type.

### DIFF
--- a/Platforms/Apple/src/AppleDebug.mm
+++ b/Platforms/Apple/src/AppleDebug.mm
@@ -45,7 +45,7 @@ void AppleDebug::AssertionFailed(const Char *Message, const char *Function, cons
 bool AppleDebug::ColoredTextSupported()
 {
     static const bool StartedFromXCode =
-        []()
+        []() -> bool
         {
             NSDictionary* environment = [[NSProcessInfo processInfo] environment];
             if (NSString* DtMode = [environment objectForKey:@"IDE_DISABLED_OS_ACTIVITY_DT_MODE"]) // Since XCode 15


### PR DESCRIPTION
I can't test this at the moment but a cast was need building on OSX. I think using the BOOL macro / typedef is the correct way to do it.