### PR TITLE
Remove viral /GL option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -405,7 +405,6 @@ if(MSVC)
     # In all release modes also:
     # - disable w4189 - local variable is initialized but not referenced
     # - Disable RTTI (/GR-)
-    # - Enable whole program optimization (/GL)
     # - Enable string pooling (/GF)
     set(MSVC_ALL_RELEASE_COMPILE_OPTIONS /wd4189 /GR- /GF)
     #target_compile_options(Diligent-BuildSettings INTERFACE "$<$<CONFIG:RELEASE>:/wd4189 /Ot")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -407,7 +407,7 @@ if(MSVC)
     # - Disable RTTI (/GR-)
     # - Enable whole program optimization (/GL)
     # - Enable string pooling (/GF)
-    set(MSVC_ALL_RELEASE_COMPILE_OPTIONS /wd4189 /GR- /GL /GF)
+    set(MSVC_ALL_RELEASE_COMPILE_OPTIONS /wd4189 /GR- /GF)
     #target_compile_options(Diligent-BuildSettings INTERFACE "$<$<CONFIG:RELEASE>:/wd4189 /Ot")
     # In RELEASE mode:
     # - Set favor fast code option (/Ot)


### PR DESCRIPTION
Was wondering why my build times went from seconds to more than a minute just changing a single file in my build project. It's because DiligentCore enables whole program optimization with MSVC, i.e. /GL.

```
26>cmake_pch.obj : MSIL .netmodule or module compiled with /GL found; restarting link with /LTCG; add /LTCG to the link command line to improve linker performance
26>LINK : warning LNK4075: ignoring '/INCREMENTAL' due to '/LTCG' specification

```

And given the size of the rest of my project, linking times end up being dramatically inflated.

I don't know of a way to disable compilation options in cmake fetched projects. And neither does the AI from what I can gather. If you have any ideas how to do this within my own CMakeLists.txt that would be extremely helpful, otherwise I'd recommend turning this option off so as to not inflate link times in projects importing Diligent.