### PR TITLE
refactor: improve MinGW detection logic in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -176,9 +176,15 @@ if(PLATFORM_WIN32 OR PLATFORM_UNIVERSAL_WINDOWS)
     endif()
 endif()
 
-if(${CMAKE_GENERATOR} MATCHES "MinGW")
-    message("Building with MinGW")
-    set(MINGW_BUILD TRUE CACHE INTERNAL "Building with MinGW")
+set(MINGW_BUILD FALSE CACHE INTERNAL "MinGW build flag")
+
+if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+    if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR
+    (CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND
+            CMAKE_CXX_COMPILER_FRONTEND_VARIANT STREQUAL "GNU"))
+        set(MINGW_BUILD TRUE CACHE INTERNAL "MinGW build flag")
+        message("Detected MinGW-${CMAKE_CXX_COMPILER_ID} toolchain")
+    endif()
 endif()
 
 if(PLATFORM_WIN32)


### PR DESCRIPTION
Replace the simple CMAKE_GENERATOR based MinGW detection with a more robust approach:
- Check if the system is Windows
- Verify compiler is either GCC or Clang with GNU frontend
- Support both MinGW-GCC and MinGW-Clang toolchains
- Fix potential false positive when using other CMake generators

This change ensures more accurate MinGW toolchain detection regardless of the CMake generator being used.