### PR TITLE
String tools: make WidenString and NarrowString work with multibyte characters

### DIFF
--- a/Common/interface/ObjectBase.hpp
+++ b/Common/interface/ObjectBase.hpp
@@ -53,11 +53,11 @@ namespace Diligent
     }
 
 #define IMPLEMENT_QUERY_INTERFACE(ClassName, InterfaceID, ParentClassName)         \
-    void ClassName::QueryInterface(const INTERFACE_ID& IID, IObject** ppInterface) \
+    void ClassName::QueryInterface(const ::Diligent::INTERFACE_ID& IID, IObject** ppInterface) \
         IMPLEMENT_QUERY_INTERFACE_BODY(InterfaceID, ParentClassName)
 
 #define IMPLEMENT_QUERY_INTERFACE_IN_PLACE(InterfaceID, ParentClassName)                                    \
-    virtual void DILIGENT_CALL_TYPE QueryInterface(const INTERFACE_ID& IID, IObject** ppInterface) override \
+    virtual void DILIGENT_CALL_TYPE QueryInterface(const ::Diligent::INTERFACE_ID& IID, IObject** ppInterface) override \
         IMPLEMENT_QUERY_INTERFACE_BODY(InterfaceID, ParentClassName)
 
 

--- a/Tests/DiligentCoreTest/src/Common/StringToolsTest.cpp
+++ b/Tests/DiligentCoreTest/src/Common/StringToolsTest.cpp
@@ -240,6 +240,11 @@ TEST(Common_StringTools, WidenString)
 
     EXPECT_EQ(WidenString(std::string{""}), std::wstring{L""});
     EXPECT_EQ(WidenString(std::string{"abc"}), std::wstring{L"abc"});
+
+    constexpr char locale_name[] = "en_US.UTF-8";
+    std::setlocale(LC_ALL, locale_name);
+    std::locale::global(std::locale(locale_name));
+    EXPECT_STREQ(WidenString("Bézier").c_str(), L"Bézier");
 }
 
 TEST(Common_StringTools, NarrowString)
@@ -250,6 +255,11 @@ TEST(Common_StringTools, NarrowString)
 
     EXPECT_EQ(NarrowString(std::wstring{L""}), std::string{""});
     EXPECT_EQ(NarrowString(std::wstring{L"abc"}), std::string{"abc"});
+
+    constexpr char locale_name[] = "en_US.UTF-8";
+    std::setlocale(LC_ALL, locale_name);
+    std::locale::global(std::locale(locale_name));
+    EXPECT_STREQ(NarrowString(L"Bézier").c_str(), u8"Bézier");
 }
 
 TEST(Common_StringTools, GetPrintWidth)


### PR DESCRIPTION
I found this little bug when open files which has CJK characters.