### PR TITLE
ObjectBase: make INTERFACE_ID fully qualified

### DIFF
--- a/Common/interface/ObjectBase.hpp
+++ b/Common/interface/ObjectBase.hpp
@@ -53,11 +53,11 @@ namespace Diligent
     }
 
 #define IMPLEMENT_QUERY_INTERFACE(ClassName, InterfaceID, ParentClassName)         \
-    void ClassName::QueryInterface(const INTERFACE_ID& IID, IObject** ppInterface) \
+    void ClassName::QueryInterface(const ::Diligent::INTERFACE_ID& IID, IObject** ppInterface) \
         IMPLEMENT_QUERY_INTERFACE_BODY(InterfaceID, ParentClassName)
 
 #define IMPLEMENT_QUERY_INTERFACE_IN_PLACE(InterfaceID, ParentClassName)                                    \
-    virtual void DILIGENT_CALL_TYPE QueryInterface(const INTERFACE_ID& IID, IObject** ppInterface) override \
+    virtual void DILIGENT_CALL_TYPE QueryInterface(const ::Diligent::INTERFACE_ID& IID, IObject** ppInterface) override \
         IMPLEMENT_QUERY_INTERFACE_BODY(InterfaceID, ParentClassName)
 
 

--- a/Common/interface/StringTools.hpp
+++ b/Common/interface/StringTools.hpp
@@ -38,9 +38,15 @@
 #include "StringTools.h"
 #include "ParsingTools.hpp"
 
+#ifdef _MSC_VER
+#    pragma warning(push)
+#    pragma warning(disable : 4996) // 'This function or variable may be unsafe': mbtowc, wctomb
+#endif
+
 namespace Diligent
 {
 
+// See also: https://en.cppreference.com/w/cpp/string/multibyte/wctomb
 inline std::string NarrowString(const wchar_t* WideStr, size_t Len = 0)
 {
     if (Len == 0)
@@ -48,11 +54,18 @@ inline std::string NarrowString(const wchar_t* WideStr, size_t Len = 0)
     else
         VERIFY_EXPR(Len <= wcslen(WideStr));
 
-    std::string NarrowStr(Len, '\0');
+    std::string NarrowStr;
+    NarrowStr.reserve(Len * 4); /* MB_CUR_MAX = 4 */
 
-    const std::ctype<wchar_t>& ctfacet = std::use_facet<std::ctype<wchar_t>>(std::wstringstream().getloc());
     for (size_t i = 0; i < Len; ++i)
-        NarrowStr[i] = ctfacet.narrow(WideStr[i], 0);
+    {
+        char mb[4];
+        int  n = wctomb(mb, WideStr[i]);
+        if (n > 0)
+        {
+            NarrowStr.append(mb, mb + n);
+        }
+    }
 
     return NarrowStr;
 }
@@ -62,6 +75,7 @@ inline std::string NarrowString(const std::wstring& WideStr)
     return NarrowString(WideStr.c_str(), WideStr.length());
 }
 
+// See also: https://en.cppreference.com/w/cpp/string/multibyte/mbtowc
 inline std::wstring WidenString(const char* Str, size_t Len = 0)
 {
     if (Len == 0)
@@ -69,11 +83,23 @@ inline std::wstring WidenString(const char* Str, size_t Len = 0)
     else
         VERIFY_EXPR(Len <= strlen(Str));
 
-    std::wstring WideStr(Len, L'\0');
+    std::wstring WideStr;
+    WideStr.reserve(Len);
 
-    const std::ctype<wchar_t>& ctfacet = std::use_facet<std::ctype<wchar_t>>(std::wstringstream().getloc());
-    for (size_t i = 0; i < Len; ++i)
-        WideStr[i] = ctfacet.widen(Str[i]);
+    for (size_t Offset = 0; Offset < Len;)
+    {
+        wchar_t wc;
+        int     n = mbtowc(&wc, Str + Offset, Len - Offset);
+        if (n > 0)
+        {
+            WideStr += wc;
+            Offset += n;
+        }
+        else
+        {
+            break;
+        }
+    }
 
     return WideStr;
 }
@@ -294,3 +320,7 @@ size_t GetPrintWidth(Type Num, Type Base = 10)
 }
 
 } // namespace Diligent
+
+#ifdef _MSC_VER
+#    pragma warning(pop)
+#endif

--- a/Tests/DiligentCoreTest/src/Common/StringToolsTest.cpp
+++ b/Tests/DiligentCoreTest/src/Common/StringToolsTest.cpp
@@ -240,6 +240,11 @@ TEST(Common_StringTools, WidenString)
 
     EXPECT_EQ(WidenString(std::string{""}), std::wstring{L""});
     EXPECT_EQ(WidenString(std::string{"abc"}), std::wstring{L"abc"});
+
+    constexpr char locale_name[] = "en_US.UTF-8";
+    std::setlocale(LC_ALL, locale_name);
+    std::locale::global(std::locale(locale_name));
+    EXPECT_STREQ(WidenString("Bézier").c_str(), L"Bézier");
 }
 
 TEST(Common_StringTools, NarrowString)
@@ -250,6 +255,11 @@ TEST(Common_StringTools, NarrowString)
 
     EXPECT_EQ(NarrowString(std::wstring{L""}), std::string{""});
     EXPECT_EQ(NarrowString(std::wstring{L"abc"}), std::string{"abc"});
+
+    constexpr char locale_name[] = "en_US.UTF-8";
+    std::setlocale(LC_ALL, locale_name);
+    std::locale::global(std::locale(locale_name));
+    EXPECT_STREQ(NarrowString(L"Bézier").c_str(), u8"Bézier");
 }
 
 TEST(Common_StringTools, GetPrintWidth)


### PR DESCRIPTION
Support implement Diligent's class interface in global or other namespaces.

For example:
```cpp
/// Implementation of Diligent::IRenderStateCache
class CustomRenderStateCache final : public Diligent::ObjectBase<Diligent::IRenderStateCache>
{
public:
    using TBase = Diligent::ObjectBase<Diligent::IRenderStateCache>;

public:
    CustomRenderStateCache(Diligent::IReferenceCounters*               pRefCounters,
                         const Diligent::RenderStateCacheCreateInfo& CreateInfo);

    IMPLEMENT_QUERY_INTERFACE_IN_PLACE(Diligent::IID_RenderStateCache, TBase);
}
```