### PR TITLE
ObjectBase: make INTERFACE_ID fully qualified

### DIFF
--- a/Common/interface/ObjectBase.hpp
+++ b/Common/interface/ObjectBase.hpp
@@ -52,11 +52,11 @@ namespace Diligent
         }                                                            \
     }
 
-#define IMPLEMENT_QUERY_INTERFACE(ClassName, InterfaceID, ParentClassName)         \
+#define IMPLEMENT_QUERY_INTERFACE(ClassName, InterfaceID, ParentClassName)                     \
     void ClassName::QueryInterface(const ::Diligent::INTERFACE_ID& IID, IObject** ppInterface) \
         IMPLEMENT_QUERY_INTERFACE_BODY(InterfaceID, ParentClassName)
 
-#define IMPLEMENT_QUERY_INTERFACE_IN_PLACE(InterfaceID, ParentClassName)                                    \
+#define IMPLEMENT_QUERY_INTERFACE_IN_PLACE(InterfaceID, ParentClassName)                                                \
     virtual void DILIGENT_CALL_TYPE QueryInterface(const ::Diligent::INTERFACE_ID& IID, IObject** ppInterface) override \
         IMPLEMENT_QUERY_INTERFACE_BODY(InterfaceID, ParentClassName)
 

--- a/Common/interface/ObjectBase.hpp
+++ b/Common/interface/ObjectBase.hpp
@@ -53,11 +53,11 @@ namespace Diligent
     }
 
 #define IMPLEMENT_QUERY_INTERFACE(ClassName, InterfaceID, ParentClassName)         \
-    void ClassName::QueryInterface(const INTERFACE_ID& IID, IObject** ppInterface) \
+    void ClassName::QueryInterface(const ::Diligent::INTERFACE_ID& IID, IObject** ppInterface) \
         IMPLEMENT_QUERY_INTERFACE_BODY(InterfaceID, ParentClassName)
 
 #define IMPLEMENT_QUERY_INTERFACE_IN_PLACE(InterfaceID, ParentClassName)                                    \
-    virtual void DILIGENT_CALL_TYPE QueryInterface(const INTERFACE_ID& IID, IObject** ppInterface) override \
+    virtual void DILIGENT_CALL_TYPE QueryInterface(const ::Diligent::INTERFACE_ID& IID, IObject** ppInterface) override \
         IMPLEMENT_QUERY_INTERFACE_BODY(InterfaceID, ParentClassName)
 
 


### PR DESCRIPTION
Support implement Diligent's class interface in global or other namespaces.

For example:
```cpp
/// Implementation of Diligent::IRenderStateCache
class CustomRenderStateCache final : public Diligent::ObjectBase<Diligent::IRenderStateCache>
{
public:
    using TBase = Diligent::ObjectBase<Diligent::IRenderStateCache>;

public:
    CustomRenderStateCache(Diligent::IReferenceCounters*               pRefCounters,
                         const Diligent::RenderStateCacheCreateInfo& CreateInfo);

    IMPLEMENT_QUERY_INTERFACE_IN_PLACE(Diligent::IID_RenderStateCache, TBase);
}
```