### PR TITLE
RenderStateCache: Use XX128Hasher to compute DeviceHash

### DIFF
--- a/Graphics/GraphicsTools/include/RenderStateCacheImpl.hpp
+++ b/Graphics/GraphicsTools/include/RenderStateCacheImpl.hpp
@@ -137,7 +137,7 @@ private:
 private:
     RefCntAutoPtr<IRenderDevice>                   m_pDevice;
     const RENDER_DEVICE_TYPE                       m_DeviceType;
-    const size_t                                   m_DeviceHash; // Hash of the device-specific properties
+    const XXH128Hash                               m_DeviceHash; // Hash of the device-specific properties
     const RenderStateCacheCreateInfo               m_CI;
     RefCntAutoPtr<IShaderSourceInputStreamFactory> m_pReloadSource;
     RefCntAutoPtr<ISerializationDevice>            m_pSerializationDevice;

--- a/Graphics/GraphicsTools/interface/XXH128Hasher.hpp
+++ b/Graphics/GraphicsTools/interface/XXH128Hasher.hpp
@@ -123,6 +123,8 @@ struct XXH128State final
 
     void Update(const ShaderCreateInfo& ShaderCI) noexcept;
 
+    void Update(const XXH128Hash& Hash) noexcept;
+
     template <typename T>
     typename std::enable_if<(std::is_same<typename std::remove_cv<T>::type, SamplerDesc>::value ||
                              std::is_same<typename std::remove_cv<T>::type, StencilOpDesc>::value ||

--- a/Graphics/GraphicsTools/src/RenderStateCacheImpl.cpp
+++ b/Graphics/GraphicsTools/src/RenderStateCacheImpl.cpp
@@ -144,13 +144,15 @@ std::string RenderStateCacheImpl::MakeHashStr(const char* Name, const XXH128Hash
 }
 
 
-static size_t ComputeDeviceAttribsHash(IRenderDevice* pDevice)
+static XXH128Hash ComputeDeviceAttribsHash(IRenderDevice* pDevice)
 {
     if (pDevice == nullptr)
-        return 0;
+        return {};
 
     const RenderDeviceInfo& DeviceInfo = pDevice->GetDeviceInfo();
-    return ComputeHash(DeviceInfo.Type, DeviceInfo.NDC.MinZ, DeviceInfo.Features.SeparablePrograms);
+    XXH128State Hasher;
+    Hasher.Update(DeviceInfo.Type, DeviceInfo.NDC.MinZ, DeviceInfo.Features.SeparablePrograms);
+    return Hasher.Digest();
 }
 
 RenderStateCacheImpl::RenderStateCacheImpl(IReferenceCounters*               pRefCounters,

--- a/Graphics/GraphicsTools/src/RenderStateCacheImpl.cpp
+++ b/Graphics/GraphicsTools/src/RenderStateCacheImpl.cpp
@@ -150,7 +150,7 @@ static XXH128Hash ComputeDeviceAttribsHash(IRenderDevice* pDevice)
         return {};
 
     const RenderDeviceInfo& DeviceInfo = pDevice->GetDeviceInfo();
-    XXH128State Hasher;
+    XXH128State             Hasher;
     Hasher.Update(DeviceInfo.Type, DeviceInfo.NDC.MinZ, DeviceInfo.Features.SeparablePrograms);
     return Hasher.Digest();
 }

--- a/Graphics/GraphicsTools/src/XXH128Hasher.cpp
+++ b/Graphics/GraphicsTools/src/XXH128Hasher.cpp
@@ -108,4 +108,9 @@ void XXH128State::Update(const ShaderCreateInfo& ShaderCI) noexcept
     }
 }
 
+void XXH128State::Update(const XXH128Hash& Hash) noexcept
+{
+    Update(Hash.LowPart, Hash.HighPart);
+}
+
 } // namespace Diligent


### PR DESCRIPTION
Which makes hash consistent between 32 and 64 bits. (#688 related)