### PR TITLE
Ability to pass down DxCompilerPath to RenderStateCache

### DIFF
--- a/Graphics/GraphicsTools/interface/RenderStateCache.h
+++ b/Graphics/GraphicsTools/interface/RenderStateCache.h
@@ -76,6 +76,9 @@ struct RenderStateCacheCreateInfo
     /// shaders. If null, original source factory will be used.
     IShaderSourceInputStreamFactory* pReloadSource DEFAULT_INITIALIZER(nullptr);
 
+    /// DX Compiler path
+    const Char* DxCompilerPath DEFAULT_INITIALIZER(nullptr);
+
 #if DILIGENT_CPP_INTERFACE
     constexpr RenderStateCacheCreateInfo() noexcept
     {}

--- a/Graphics/GraphicsTools/src/RenderStateCacheImpl.cpp
+++ b/Graphics/GraphicsTools/src/RenderStateCacheImpl.cpp
@@ -191,6 +191,7 @@ RenderStateCacheImpl::RenderStateCacheImpl(IReferenceCounters*               pRe
 
         case RENDER_DEVICE_TYPE_D3D12:
             SerializationDeviceCI.D3D12.ShaderVersion = SerializationDeviceCI.DeviceInfo.MaxShaderVersion.HLSL;
+            SerializationDeviceCI.D3D12.DxCompilerPath = CreateInfo.DxCompilerPath;
             break;
 
         case RENDER_DEVICE_TYPE_GL:
@@ -201,6 +202,7 @@ RenderStateCacheImpl::RenderStateCacheImpl(IReferenceCounters*               pRe
 
         case RENDER_DEVICE_TYPE_VULKAN:
             SerializationDeviceCI.Vulkan.ApiVersion = SerializationDeviceCI.DeviceInfo.APIVersion;
+            SerializationDeviceCI.Vulkan.DxCompilerPath = CreateInfo.DxCompilerPath;
             break;
 
         case RENDER_DEVICE_TYPE_METAL:


### PR DESCRIPTION
Hi,

Here's a tiny change to add the option to pass the path to DXC in `RenderStateCacheCreateInfo`. Useful on Linux and OSX, otherwise it defaults to `dxcompiler` or `spv_dxcompiler`.

On a note, we have been running `DXCompilerLibraryLinux.cpp` on OSX with the `dxcompiler.dylib` shipped in the Vulkan SDK. I understand this is not supported from looking at the CMakeLists.txt but is there a technical reason or just lack of resources?