### PR TITLE
Fix: no-enum-constexpr-conversion compilation error of DX12 backend with clang-cl

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -486,7 +486,6 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
         INTERFACE
             -Wno-microsoft-exception-spec
             -Wno-tautological-constant-out-of-range-compare
-            -Wno-enum-constexpr-conversion
         )
     elseif (PLATFORM_APPLE)
         # Allow unavailable API warnings not being errors as they tend to randomly

--- a/Graphics/GraphicsEngineD3D12/src/RootParamsManager.cpp
+++ b/Graphics/GraphicsEngineD3D12/src/RootParamsManager.cpp
@@ -39,7 +39,7 @@ namespace Diligent
 namespace
 {
 
-constexpr D3D12_DESCRIPTOR_RANGE_TYPE InvalidDescriptorRangeType = static_cast<D3D12_DESCRIPTOR_RANGE_TYPE>(-1);
+const D3D12_DESCRIPTOR_RANGE_TYPE InvalidDescriptorRangeType = static_cast<D3D12_DESCRIPTOR_RANGE_TYPE>(-1);
 
 #ifdef DILIGENT_DEBUG
 void DbgValidateD3D12RootTable(const D3D12_ROOT_DESCRIPTOR_TABLE& d3d12Tbl)


### PR DESCRIPTION
### Summary

This PR removes the `-Wno-enum-constexpr-conversion` compiler flag from
the D3D12 graphics engine build. The original warning suppression is no
longer necessary because:

1. Clang now treats the conversion from an invalid enum value in a
   constexpr context as an error that cannot be suppressed
   (https://github.com/llvm/llvm-project/issues/59036).

2. The code in `RootParamsManager.cpp` has been updated: the
   `InvalidDescriptorRangeType` is now a `const` instead of `constexpr`,
   making the conversion from `-1` valid.

### Changes

- Removed `-Wno-enum-constexpr-conversion` from Clang compile options.
- Changed `InvalidDescriptorRangeType` from `constexpr` to `const`.
- No longer requires suppression of the enum conversion warning.

This makes the code compatible with newer Clang versions and removes
unnecessary warning suppressions.