### PR TITLE
FIX: Clang and MSVC compile options duplicate for clang-cl

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -468,14 +468,17 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
         message("Additional Clang compile options for release configurations: " ${DILIGENT_CLANG_RELEASE_COMPILE_OPTIONS})
     endif()
 
-    target_compile_options(Diligent-BuildSettings INTERFACE
-        ${DILIGENT_CLANG_COMPILE_OPTIONS}
-        # Some extra warnings
-        -Wall -Wextra -Wuninitialized -Wconditional-uninitialized -Wextra-tokens -Wpointer-arith -Wloop-analysis -Wunused
-        # Disable few warnings
-        -Wno-overloaded-virtual -Wno-incompatible-pointer-types-discards-qualifiers -Wno-unknown-pragmas
-        -Wno-zero-as-null-pointer-constant -Wno-unused-parameter -Wno-invalid-offsetof
-    )
+    target_compile_options(Diligent-BuildSettings INTERFACE ${DILIGENT_CLANG_COMPILE_OPTIONS})
+
+    if(NOT MSVC)
+        target_compile_options(Diligent-BuildSettings INTERFACE
+            # Some extra warnings
+            -Wall -Wextra -Wuninitialized -Wconditional-uninitialized -Wextra-tokens -Wpointer-arith -Wloop-analysis -Wunused
+            # Disable few warnings
+            -Wno-overloaded-virtual -Wno-incompatible-pointer-types-discards-qualifiers -Wno-unknown-pragmas
+            -Wno-zero-as-null-pointer-constant -Wno-unused-parameter -Wno-invalid-offsetof -Wno-c++98-compat -Wunsafe-buffer-usage
+        )
+    endif()
     target_compile_options(Diligent-BuildSettings INTERFACE "$<$<CONFIG:DEBUG>:${DILIGENT_CLANG_DEBUG_COMPILE_OPTIONS}>")
 
     set(CLANG_RELEASE_OPTIONS -Wno-unused-variable ${DILIGENT_CLANG_RELEASE_COMPILE_OPTIONS})


### PR DESCRIPTION
### Summary

When building with clang-cl (Clang frontend for MSVC):

- Previously, both Clang-specific and MSVC-specific compiler flags were
  applied, producing duplicate warnings and huge warning output.
- Compilation could slow down by orders of magnitude due to -Wall/-Wextra.

### Changes

- Clang-cl now only uses MSVC-specific compile options.
- Pure Clang builds continue using Clang-specific warnings and suppressions.
- Redundant -Wall/-Wextra removed for clang-cl.

### Benefits

- Builds with clang-cl are significantly faster.
- Warning output is reasonable and manageable.
- Maintains correct compile flags for each compiler.