### PR TITLE
OpenXRUtilities fixes

### DIFF
--- a/Graphics/GraphicsTools/interface/OpenXRUtilities.h
+++ b/Graphics/GraphicsTools/interface/OpenXRUtilities.h
@@ -31,7 +31,7 @@
 
 #include "../../GraphicsEngine/interface/RenderDevice.h"
 #include "../../GraphicsEngine/interface/DeviceContext.h"
-#include "../../Primitives/interface/DataBlob.h"
+#include "../../../Primitives/interface/DataBlob.h"
 
 #include <openxr/openxr.h>
 

--- a/Graphics/GraphicsTools/src/OpenXRUtilities.cpp
+++ b/Graphics/GraphicsTools/src/OpenXRUtilities.cpp
@@ -375,7 +375,7 @@ extern "C"
         Diligent::DestroyOpenXRDebugUtilsMessenger(debugUtilsMessenger);
     }
 
-    void Dilgent_AllocateOpenXRSwapchainImageData(Diligent::RENDER_DEVICE_TYPE DeviceType,
+    void Diligent_AllocateOpenXRSwapchainImageData(Diligent::RENDER_DEVICE_TYPE DeviceType,
                                                   Diligent::Uint32             ImageCount,
                                                   Diligent::IDataBlob**        ppSwapchainImageData)
     {


### PR DESCRIPTION
- modified an include path in OpenXRUtilities.h to be the correct relative path.
- fixed a typo in the C API in OpenXRUtilities.cpp