### PR TITLE
Use CMake's MINGW variable instead of checking generator name

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -171,8 +171,11 @@ if(PLATFORM_WIN32 OR PLATFORM_UNIVERSAL_WINDOWS)
     endif()
 endif()
 
-if(${CMAKE_GENERATOR} MATCHES "MinGW")
+if(MINGW)
     message("Building with MinGW")
+    if(MSYS)
+        message("  in MSYS environment")
+    endif()
     set(MINGW_BUILD TRUE CACHE INTERNAL "Building with MinGW")
 endif()
 


### PR DESCRIPTION
The generator name check was unreliable - CMake already detects MinGW properly via the MINGW variable. This works regardless of which generator (Makefiles/Ninja/etc) is being used.

Also added MSYS environment detection for completeness.