### PR TITLE
Debuggable shaders

### DIFF
--- a/Graphics/ShaderTools/src/GLSLangUtils.cpp
+++ b/Graphics/ShaderTools/src/GLSLangUtils.cpp
@@ -82,7 +82,7 @@ EShLanguage ShaderTypeToShLanguage(SHADER_TYPE ShaderType)
     static_assert(SHADER_TYPE_LAST == 0x4000, "Please handle the new shader type in the switch below");
     switch (ShaderType)
     {
-        // clang-format off
+            // clang-format off
         case SHADER_TYPE_VERTEX:           return EShLangVertex;
         case SHADER_TYPE_HULL:             return EShLangTessControl;
         case SHADER_TYPE_DOMAIN:           return EShLangTessEvaluation;
@@ -294,11 +294,11 @@ std::vector<unsigned int> CompileShaderInternal(::glslang::TShader&           Sh
     ::glslang::SpvOptions spvOptions;
 #ifdef DILIGENT_DEBUG
     spvOptions.generateDebugInfo = true;
-#if DILIGENT_NO_HLSL
+#    if DILIGENT_NO_HLSL
     // will be stripped anyway with HLSL support anyway
-    spvOptions.emitNonSemanticShaderDebugInfo = true;
+    spvOptions.emitNonSemanticShaderDebugInfo   = true;
     spvOptions.emitNonSemanticShaderDebugSource = true;
-#endif
+#    endif
 #endif
     std::vector<unsigned int> spirv;
     ::glslang::GlslangToSpv(*Program.getIntermediate(Shader.getStage()), spirv, &spvOptions);
@@ -421,7 +421,7 @@ spv_target_env SpirvVersionToSpvTargetEnv(SpirvVersion Version)
     static_assert(static_cast<int>(SpirvVersion::Count) == 6, "Did you add a new member to SpirvVersion? You may need to handle it here.");
     switch (Version)
     {
-        // clang-format off
+            // clang-format off
         case SpirvVersion::Vk100:         return SPV_ENV_VULKAN_1_0;
         case SpirvVersion::Vk110:         return SPV_ENV_VULKAN_1_1;
         case SpirvVersion::Vk110_Spirv14: return SPV_ENV_VULKAN_1_1_SPIRV_1_4;


### PR DESCRIPTION
Embedd debug info in compiled SpirV shaders when in debug.

This enables debugging shaders in tools like RenderDoc.

Maybe this shouldn't be tied to the engines Debug Mode? Not sure which other config to use though.