### PR TITLE
Allow diligent to link a static DirectXShaderCompiler

### DIFF
--- a/Graphics/ShaderTools/CMakeLists.txt
+++ b/Graphics/ShaderTools/CMakeLists.txt
@@ -18,6 +18,8 @@ set(SOURCE
     src/HLSLTokenizer.cpp
 )
 
+option(DILIGENT_USE_STATIC_DXC "Link DXC statically and bypass dlopen" OFF)
+
 set(DXC_SUPPORTED FALSE)
 if((PLATFORM_WIN32 AND NOT MINGW_BUILD) OR PLATFORM_UNIVERSAL_WINDOWS OR PLATFORM_LINUX)
     set(DXC_SUPPORTED TRUE)
@@ -143,8 +145,14 @@ if (DXC_SUPPORTED)
     endif()
 
     if (NOT PLATFORM_WIN32)
-        if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR
-            CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+        if (DILIGENT_USE_STATIC_DXC)
+            target_compile_definitions(Diligent-ShaderTools PRIVATE DILIGENT_USE_STATIC_DXC=1)
+            target_link_libraries(Diligent-ShaderTools
+                    PUBLIC
+                    LLVMSupport
+                    dxcompiler
+            )
+        elseif (CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID MATCHES "GNU")
             target_link_libraries(Diligent-ShaderTools PRIVATE dl)
         endif()
     endif()
@@ -176,6 +184,13 @@ if(ENABLE_SPIRV)
     endif()
 
     if (${USE_SPIRV_TOOLS})
+        if (NOT PLATFORM_WIN32 AND DILIGENT_USE_STATIC_DXC)
+            cmake_policy(SET CMP0079 NEW)
+            target_link_libraries(SPIRV-Tools-opt
+                PUBLIC
+                LLVMSupport
+            )
+        endif()
         target_link_libraries(Diligent-ShaderTools
         PRIVATE
             SPIRV-Tools-opt

--- a/Graphics/ShaderTools/src/DXCompilerLibraryLinux.cpp
+++ b/Graphics/ShaderTools/src/DXCompilerLibraryLinux.cpp
@@ -33,26 +33,34 @@ namespace Diligent
 
 void DXCompilerLibrary::Load()
 {
+#if defined(DILIGENT_USE_STATIC_DXC)
+    m_Library = reinterpret_cast<void*>(0x1);
+    m_DxcCreateInstance = &DxcCreateInstance;
+#else
     if (!m_LibName.empty())
         m_Library = dlopen(m_LibName.c_str(), RTLD_LOCAL | RTLD_LAZY);
 
     if (m_Library == nullptr)
         m_Library = dlopen("libdxcompiler.so", RTLD_LOCAL | RTLD_LAZY);
 
-    // try to load from default path
     if (m_Library == nullptr)
         m_Library = dlopen("/usr/lib/dxc/libdxcompiler.so", RTLD_LOCAL | RTLD_LAZY);
 
-    m_DxcCreateInstance = m_Library != nullptr ? reinterpret_cast<DxcCreateInstanceProc>(dlsym(m_Library, "DxcCreateInstance")) : nullptr;
+    m_DxcCreateInstance = m_Library != nullptr
+        ? reinterpret_cast<DxcCreateInstanceProc>(dlsym(m_Library, "DxcCreateInstance"))
+        : nullptr;
+#endif
 }
 
 void DXCompilerLibrary::Unload()
 {
+#if !defined(DILIGENT_USE_STATIC_DXC)
     if (m_Library != nullptr)
     {
         dlclose(m_Library);
         m_Library = nullptr;
     }
+#endif
 }
 
 } // namespace Diligent


### PR DESCRIPTION
Add a flag (off by default) to allow diligent to use a statically-linked DirectXShaderCompiler