### PR TITLE
Fix ConvertUBOToPushConstant: The pointer type instruction need to be reordered

### DIFF
--- a/Graphics/ShaderTools/src/ConvertUBOToPushConstant.cpp
+++ b/Graphics/ShaderTools/src/ConvertUBOToPushConstant.cpp
@@ -280,8 +280,10 @@ private:
     bool ComesBeforeInTypesValues(const spvtools::opt::Instruction* a,
                                   const spvtools::opt::Instruction* b) const
     {
-        if (a == nullptr || b == nullptr || a == b)
+        if (a == nullptr || b == nullptr)
             return false;
+        if (a == b)
+            return true; // Same instruction, no reordering needed
 
         bool seen_a = false;
         for (auto& inst : context()->module()->types_values())


### PR DESCRIPTION
otherwise the SPIRV might be rejected by validation layer due to violating SPIR-V validation rules.