### PR TITLE
SetInlineConstants support for OpenGL

### DIFF
--- a/Graphics/GraphicsEngineOpenGL/include/DeviceContextGLImpl.hpp
+++ b/Graphics/GraphicsEngineOpenGL/include/DeviceContextGLImpl.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2019-2025 Diligent Graphics LLC
+ *  Copyright 2019-2026 Diligent Graphics LLC
  *  Copyright 2015-2019 Egor Yusov
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -325,7 +325,7 @@ private:
     __forceinline void PostDraw();
 
     using TBindings = PipelineResourceSignatureGLImpl::TBindings;
-    void BindProgramResources(Uint32 BindSRBMask);
+    void BindProgramResources(Uint32 BindSRBMask, bool DynamicBuffersIntact = false, bool InlineConstantsIntact = false);
 
 #ifdef DILIGENT_DEVELOPMENT
     void DvpValidateCommittedShaderResources();

--- a/Tests/DiligentCoreAPITest/src/InlineConstantsTest.cpp
+++ b/Tests/DiligentCoreAPITest/src/InlineConstantsTest.cpp
@@ -213,7 +213,7 @@ protected:
         GPUTestingEnvironment* pEnv    = GPUTestingEnvironment::GetInstance();
         IRenderDevice*         pDevice = pEnv->GetDevice();
 
-        if (!pDevice->GetDeviceInfo().IsD3DDevice() && !pDevice->GetDeviceInfo().IsVulkanDevice())
+        if (!pDevice->GetDeviceInfo().IsD3DDevice() && !pDevice->GetDeviceInfo().IsVulkanDevice() && !pDevice->GetDeviceInfo().IsGLDevice())
         {
             GTEST_SKIP();
         }


### PR DESCRIPTION
Build plan: [SetInlineConstantsGL](https://github.com/hzqst/DiligentCore/blob/inline_constants_747_2/plan/SetInlineConstantsGL.md)

- [x]  **Step 1**: [Define `InlineConstantBufferAttribsGL` structure](https://github.com/hzqst/DiligentCore/blob/inline_constants_747_2/plan/SetInlineConstantsGL.md#1-define-inline-constant-metadata-for-gl-signatures)
- [x] **Step 1.5**: [Fix ArraySize in GetDefaultSignatureDesc for inline constants](https://github.com/hzqst/DiligentCore/blob/inline_constants_747_2/plan/SetInlineConstantsGL.md#15-fix-arraysize-in-getdefaultsignaturedesc-for-inline-constants)
- [x]  **Step 2**: [Fix binding count calculation in `CreateLayout` (use `GetArraySize()`) and create shared buffer](https://github.com/hzqst/DiligentCore/blob/inline_constants_747_2/plan/SetInlineConstantsGL.md#2-fix-binding-counts-for-inline-constants-in-gl-layout)
- [x]  **Step 3**: [Extend `ShaderResourceCacheGL` for inline constant staging](https://github.com/hzqst/DiligentCore/blob/inline_constants_747_2/plan/SetInlineConstantsGL.md#3-extend-shaderresourcecachegl-for-inline-constant-staging)
- [x]  **Step 3.5**: [Fix SRB memory size estimate to include inline constants](https://github.com/hzqst/DiligentCore/blob/inline_constants_747_2/plan/SetInlineConstantsGL.md#35-fix-srb-memory-size-estimate-to-include-inline-constants)
- [x]  **Step 4**: [Initialize SRB cache and bind shared buffer](https://github.com/hzqst/DiligentCore/blob/inline_constants_747_2/plan/SetInlineConstantsGL.md#4-initialize-srb-cache-with-inline-constant-buffers)
- [x]  **Step 4.5**: [Fix StaticResCache: Only initialize static inline constants in static cache](https://github.com/hzqst/DiligentCore/blob/inline_constants_747_2/plan/SetInlineConstantsGL.md#45-bug-fix-only-initialize-static-inline-constants-in-static-cache)
- [x]  **Step 5**: [Implement `ShaderVariableManagerGL::SetConstants`](https://github.com/hzqst/DiligentCore/blob/inline_constants_747_2/plan/SetInlineConstantsGL.md#5-implement-setinlineconstants-in-shadervariablemanagergl)
- [x]  **Step 6**: [Add commit path in `DeviceContextGLImpl` (graphics + compute)](https://github.com/hzqst/DiligentCore/blob/inline_constants_747_2/plan/SetInlineConstantsGL.md#6-commit-path-update-ubos-before-binding)
- [x]  **Step 7**: [Implement static inline constants copy](https://github.com/hzqst/DiligentCore/blob/inline_constants_747_2/plan/SetInlineConstantsGL.md#7-copy-static-inline-constants-into-srb-cache)
- [x]  **Step 8**: [Enable tests](https://github.com/hzqst/DiligentCore/blob/inline_constants_747_2/plan/SetInlineConstantsGL.md#8-enable-tests)
- [x] **Step 8.5**: [Bug fix: Re-bind inline constant buffers after update when using compatible SRB](https://github.com/hzqst/DiligentCore/blob/inline_constants_747_2/plan/SetInlineConstantsGL.md#85-bug-fix-re-bind-inline-constant-buffers-after-update-when-using-compatible-srb)
- [x] **Step 8.6**: [Fix : buffer block with binding `0` has mismatching definitions from `RenderStateCache` test. see comment later.](https://github.com/hzqst/DiligentCore/blob/inline_constants_747_2/plan/SetInlineConstantsGL.md#86-fix-buffer-block-with-binding-0-has-mismatching-definitions-renderstatecache-test)
