### PR TITLE
Fixed array arguments during conversion from HLSL to GLSL

### DIFF
--- a/Graphics/HLSL2GLSLConverterLib/src/HLSL2GLSLConverterImpl.cpp
+++ b/Graphics/HLSL2GLSLConverterLib/src/HLSL2GLSLConverterImpl.cpp
@@ -2776,7 +2776,7 @@ void InitVariable(const String& Name, const String& InitValue, std::stringstream
     OutSS << "    " << Name << " = " << InitValue << ";\n";
 }
 
-void DefineInterfaceVar(int location, const char* interpolation, const char* inout, const String& ParamType, const String& ParamName, std::stringstream& OutSS)
+void DefineInterfaceVar(int location, const char* interpolation, const char* inout, const String& ParamType, const String& ParamName, const String& ArraySize, std::stringstream& OutSS)
 {
     if (location >= 0)
     {
@@ -2786,7 +2786,12 @@ void DefineInterfaceVar(int location, const char* interpolation, const char* ino
     {
         OutSS << interpolation << ' ';
     }
-    OutSS << inout << ' ' << ParamType << ' ' << ParamName << ";\n";
+    OutSS << inout << ' ' << ParamType << ' ' << ParamName;
+    if (!ArraySize.empty())
+    {
+        OutSS << '[' << ArraySize << ']';
+    }
+    OutSS << ";\n";
 }
 
 String HLSL2GLSLConverterImpl::ConversionStream::BuildParameterName(
@@ -2944,7 +2949,7 @@ void HLSL2GLSLConverterImpl::ConversionStream::ProcessFragmentShaderArguments(To
                         auto InputVarName = BuildParameterName(MemberStack, '_', m_bUseInOutLocationQualifiers ? "_psin_" : "_");
                         DefineInterfaceVar(m_bUseInOutLocationQualifiers ? InLocation++ : -1,
                                            GetInterpolationQualifier(Param), "in",
-                                           Param.Type, InputVarName, InterfaceVarsSS);
+                                           Param.Type, InputVarName, MemberStack.back()->ArraySize, InterfaceVarsSS);
                         InitVariable(FullParamName, InputVarName, PrologueSS);
                     }
                 } //
@@ -2986,7 +2991,7 @@ void HLSL2GLSLConverterImpl::ConversionStream::ProcessFragmentShaderArguments(To
                             String OutVarName = BuildParameterName(MemberStack, '_', "_psout_");
                             // Fragment shader outputs can't have interpolation qualifiers
                             const char* Interpolation = nullptr;
-                            DefineInterfaceVar(RTIndex, Interpolation, "out", Param.Type, OutVarName, GlobalVarsSS);
+                            DefineInterfaceVar(RTIndex, Interpolation, "out", Param.Type, OutVarName, MemberStack.back()->ArraySize, GlobalVarsSS);
                             ReturnHandlerSS << OutVarName << " = " << FullParamName << ";\\\n";
                         }
                         else
@@ -3051,7 +3056,7 @@ void HLSL2GLSLConverterImpl::ConversionStream::ProcessVertexShaderArguments(std:
                         // Interpolation qualifiers are not allowed on VS inputs.
                         const char* Interpolation = nullptr;
                         // Layout location qualifiers are allowed on VS inputs even in GLES3.0.
-                        DefineInterfaceVar(InputLocation, Interpolation, "in", Param.Type, InputVarName, GlobalVarsSS);
+                        DefineInterfaceVar(InputLocation, Interpolation, "in", Param.Type, InputVarName, MemberStack.back()->ArraySize, GlobalVarsSS);
                         InitVariable(FullParamName, InputVarName, PrologueSS);
                         AutoInputLocation++;
                     }
@@ -3073,7 +3078,7 @@ void HLSL2GLSLConverterImpl::ConversionStream::ProcessVertexShaderArguments(std:
                         auto OutputVarName = BuildParameterName(MemberStack, '_', m_bUseInOutLocationQualifiers ? "_vsout_" : "_");
                         DefineInterfaceVar(m_bUseInOutLocationQualifiers ? OutLocation++ : -1,
                                            GetInterpolationQualifier(Param), "out",
-                                           Param.Type, OutputVarName, InterfaceVarsSS);
+                                           Param.Type, OutputVarName, MemberStack.back()->ArraySize, InterfaceVarsSS);
                         ReturnHandlerSS << OutputVarName << " = " << FullParamName << ";\\\n";
                     }
                 } //
@@ -3167,7 +3172,7 @@ void HLSL2GLSLConverterImpl::ConversionStream::ProcessGeometryShaderArguments(To
                             auto InputVarName = VarName + "[i]";
                             DefineInterfaceVar(m_bUseInOutLocationQualifiers ? inLocation++ : -1,
                                                GetInterpolationQualifier(Param), "in",
-                                               Param.Type, VarName + "[]", InterfaceVarsInSS);
+                                               Param.Type, VarName + "[]", "", InterfaceVarsInSS);
                             InitVariable(FullIndexedParamName, InputVarName, PrologueSS);
                         }
                     } //
@@ -3211,7 +3216,7 @@ void HLSL2GLSLConverterImpl::ConversionStream::ProcessGeometryShaderArguments(To
                         auto OutputVarName = BuildParameterName(MemberStack, '_', m_bUseInOutLocationQualifiers ? "_gsout_" : "_");
                         DefineInterfaceVar(m_bUseInOutLocationQualifiers ? outLocation++ : -1,
                                            GetInterpolationQualifier(Param), "out",
-                                           Param.Type, OutputVarName, InterfaceVarsOutSS);
+                                           Param.Type, OutputVarName, MemberStack.back()->ArraySize, InterfaceVarsOutSS);
                         EmitVertexDefineSS << OutputVarName << " = " << MacroArgumentName << ";\\\n";
                     }
                 } //
@@ -3724,7 +3729,7 @@ void HLSL2GLSLConverterImpl::ConversionStream::ProcessHullShaderArguments(TokenL
                         // User-defined inputs can be declared as unbounded arrays
                         DefineInterfaceVar(m_bUseInOutLocationQualifiers ? inLocation++ : -1,
                                            GetInterpolationQualifier(Param), "in",
-                                           Param.Type, VarName + (IsPatch ? "[]" : ""), InterfaceVarsInSS);
+                                           Param.Type, VarName + (IsPatch ? "[]" : ""), "", InterfaceVarsInSS);
                         InitVariable(FullIndexedParamName, InputVarName, PrologueSS);
                     }
                 } //
@@ -3757,7 +3762,7 @@ void HLSL2GLSLConverterImpl::ConversionStream::ProcessHullShaderArguments(TokenL
                         // https://www.khronos.org/opengl/wiki/Tessellation_Control_Shader#Outputs
                         DefineInterfaceVar(m_bUseInOutLocationQualifiers ? outLocation++ : -1,
                                            GetInterpolationQualifier(Param), "out",
-                                           Param.Type, OutputVarName + "[]", InterfaceVarsOutSS);
+                                           Param.Type, OutputVarName + "[]", "", InterfaceVarsOutSS);
                         // A TCS can only ever write to the per-vertex output variable that corresponds to their invocation,
                         // so writes to per-vertex outputs must be of the form vertexTexCoord[gl_InvocationID]
                         ReturnHandlerSS << OutputVarName << "[gl_InvocationID] = " << SrcParamName << ";\\\n";
@@ -3941,7 +3946,7 @@ void HLSL2GLSLConverterImpl::ConversionStream::ProcessDomainShaderArguments(Toke
                         // User-defined inputs can be declared as unbounded arrays
                         DefineInterfaceVar(m_bUseInOutLocationQualifiers ? inLocation++ : -1,
                                            GetInterpolationQualifier(Param), "in",
-                                           Param.Type, VarName + (IsPatch ? "[]" : ""), InterfaceVarsInSS);
+                                           Param.Type, VarName + (IsPatch ? "[]" : ""), "", InterfaceVarsInSS);
                         InitVariable(FullIndexedParamName, InputVarName, PrologueSS);
                     }
                     else
@@ -3969,7 +3974,7 @@ void HLSL2GLSLConverterImpl::ConversionStream::ProcessDomainShaderArguments(Toke
                         // https://www.khronos.org/opengl/wiki/Tessellation_Control_Shader#Outputs
                         DefineInterfaceVar(m_bUseInOutLocationQualifiers ? outLocation++ : -1,
                                            GetInterpolationQualifier(Param), "out",
-                                           Param.Type, OutputVarName, InterfaceVarsOutSS);
+                                           Param.Type, OutputVarName, MemberStack.back()->ArraySize, InterfaceVarsOutSS);
                         // A TCS can only ever write to the per-vertex output variable that corresponds to their invocation,
                         // so writes to per-vertex outputs must be of the form vertexTexCoord[gl_InvocationID]
                         ReturnHandlerSS << OutputVarName << " = " << SrcParamName << ";\\\n";


### PR DESCRIPTION
Hello, I think I found a bug in HLSL2GLSLConverterLib where array members within an HLSL shader output structure are incorrectly translated into scalar (non-array) out variables in GLSL. This mismatch results in compilation error: `error C1035: assignment of incompatible types`.

### Minimal Example
Vertex shader
```slang
struct VSInput {
    float3 pos : ATTRIB0;
};

struct PSInput {
    float4 pos : SV_POSITION;
    float4 offsets[2] : OFFSET; // here is the problematic array
};

void main(in VSInput VSIn, out PSInput PSIn) {
    PSIn.pos = float4(VSIn.pos, 1.0) + PSIn.offsets[0] + PSIn.offsets[1];
}
```

Code
```c++
    Diligent::IRenderDevice* RenderDevice = ...;
    std::string Source = ...;
    
    Diligent::ShaderCreateInfo ShaderCI;
    ShaderCI.SourceLanguage = Diligent::SHADER_SOURCE_LANGUAGE_HLSL;
    ShaderCI.CompileFlags = Diligent::SHADER_COMPILE_FLAG_PACK_MATRIX_ROW_MAJOR;
    ShaderCI.Desc.UseCombinedTextureSamplers = true;
    ShaderCI.Desc.ShaderType = Diligent::SHADER_TYPE_VERTEX;
    ShaderCI.Source = Source.c_str();

    Diligent::RefCntAutoPtr<Diligent::IShader> Shader;
    RenderDevice->CreateShader(ShaderCI, &Shader);
```

HLSL2GLSLConverterLib Output
```glsl
// ...
struct VSInput {
    float3 pos;
};

struct PSInput {
    float4 pos;
    float4 offsets[2];
};

layout(location = 0) in float3 _vsin_VSIn_pos;
out float4 _PSIn_offsets; // <-------------------------- missing [2]

#define _RETURN_ {\
_SET_GL_POSITION(PSIn.pos);\
_PSIn_offsets = PSIn.offsets;\
return;}

void main() {
    VSInput VSIn;
    VSIn.pos = _vsin_VSIn_pos;
    PSInput PSIn;

    PSIn.pos = float4(VSIn.pos, 1.0) + PSIn.offsets[0] + PSIn.offsets[1];
_RETURN_
}
```

Error message `0(1209) : error C1035: assignment of incompatible types` points to `_RETURN_` (`_PSIn_offsets = PSIn.offsets;`)