### PR TITLE
Handle GPU timestamp overflow

### DIFF
--- a/Graphics/GraphicsEngineVulkan/include/QueryManagerVk.hpp
+++ b/Graphics/GraphicsEngineVulkan/include/QueryManagerVk.hpp
@@ -72,6 +72,11 @@ public:
         return m_CounterFrequency;
     }
 
+    Uint32 GetTimestampValidBits() const
+    {
+        return m_TimestampValidBits;
+    }
+
     Uint32 ResetStaleQueries(const VulkanUtilities::LogicalDevice& LogicalDevice,
                              VulkanUtilities::CommandBuffer&       CmdBuff);
 
@@ -139,7 +144,8 @@ private:
 
     std::array<QueryPoolInfo, QUERY_TYPE_NUM_TYPES> m_Pools;
 
-    Uint64 m_CounterFrequency = 0;
+    Uint64 m_CounterFrequency   = 0;
+    Uint32 m_TimestampValidBits = 0;
 };
 
 } // namespace Diligent

--- a/Graphics/GraphicsEngineVulkan/src/QueryManagerVk.cpp
+++ b/Graphics/GraphicsEngineVulkan/src/QueryManagerVk.cpp
@@ -164,6 +164,8 @@ QueryManagerVk::QueryManagerVk(RenderDeviceVkImpl* pRenderDeviceVk,
     const bool                      IsTransferQueue        = (QueueFlags & (VK_QUEUE_COMPUTE_BIT | VK_QUEUE_GRAPHICS_BIT)) == 0;
     const bool                      QueueSupportsTimestamp = PhysicalDevice.GetQueueProperties()[QueueFamilyIndex].timestampValidBits > 0;
 
+    m_TimestampValidBits = PhysicalDevice.GetQueueProperties()[QueueFamilyIndex].timestampValidBits;
+
     for (Uint32 query_type = QUERY_TYPE_UNDEFINED + 1; query_type < QUERY_TYPE_NUM_TYPES; ++query_type)
     {
         const QUERY_TYPE QueryType = static_cast<QUERY_TYPE>(query_type);

--- a/Graphics/GraphicsEngineVulkan/src/QueryVkImpl.cpp
+++ b/Graphics/GraphicsEngineVulkan/src/QueryVkImpl.cpp
@@ -243,6 +243,7 @@ inline bool GetDurationQueryData(const VulkanUtilities::LogicalDevice& LogicalDe
                                  VkQueryPool                           vkQueryPool,
                                  const std::array<Uint32, 2>&          QueryIdx,
                                  Uint64                                CounterFrequency,
+                                 Uint32                                TimestampValidBits,
                                  void*                                 pData,
                                  Uint32                                DataSize)
 {
@@ -263,8 +264,8 @@ inline bool GetDurationQueryData(const VulkanUtilities::LogicalDevice& LogicalDe
     {
         QueryDataDuration& QueryData = *reinterpret_cast<QueryDataDuration*>(pData);
         VERIFY_EXPR(DataSize == sizeof(QueryData));
-        VERIFY_EXPR(EndCounter >= StartCounter);
-        QueryData.Duration  = EndCounter - StartCounter;
+        DEV_CHECK_WARN(EndCounter >= StartCounter, "GPU time overflowed");
+        QueryData.Duration  = (EndCounter - StartCounter) & (~0ull >> (64 - TimestampValidBits));
         QueryData.Frequency = CounterFrequency;
     }
 
@@ -355,7 +356,7 @@ bool QueryVkImpl::GetData(void* pData, Uint32 DataSize, bool AutoInvalidate)
                 break;
 
             case QUERY_TYPE_DURATION:
-                DataAvailable = GetDurationQueryData(LogicalDevice, vkQueryPool, m_QueryPoolIndex, m_pQueryMgr->GetCounterFrequency(), pData, DataSize);
+                DataAvailable = GetDurationQueryData(LogicalDevice, vkQueryPool, m_QueryPoolIndex, m_pQueryMgr->GetCounterFrequency(), m_pQueryMgr->GetTimestampValidBits(), pData, DataSize);
                 break;
 
             default:


### PR DESCRIPTION
Vulkan only guarantees 36 bits of timestamp, some Intel IGPUs (Core i7-14700HX) report
```
 timestampValidBits          = 36
 timestampPeriod                                 = 52.0833
```
resulting in an overflow after just one hour.

This commit implements proper handling for an overflow while measuring time (assuming you don't have two) and loggs a warning on overflow.