### PR TITLE
Fix segfault when saving RenderCache

### DIFF
--- a/Graphics/GraphicsTools/interface/RenderStateCache.hpp
+++ b/Graphics/GraphicsTools/interface/RenderStateCache.hpp
@@ -210,8 +210,10 @@ public:
             if (pCacheData)
             {
                 FileWrapper CacheDataFile{FilePath, EFileAccessMode::Overwrite};
-                if (CacheDataFile->Write(pCacheData->GetConstDataPtr(), pCacheData->GetSize()))
+                if (CacheDataFile && CacheDataFile->Write(pCacheData->GetConstDataPtr(), pCacheData->GetSize()))
                     LOG_INFO_MESSAGE("Successfully saved state cache file ", FilePath, " (", FormatMemorySize(pCacheData->GetSize()), ").");
+                else
+                    LOG_ERROR_MESSAGE("Failed to save state cache file ", FilePath, " (", FormatMemorySize(pCacheData->GetSize()), ").");
             }
         }
         else


### PR DESCRIPTION
When the `CacheDataFile` could not be opened, the `->` operator returns a `nullptr` and then calling `Write` crashes.